### PR TITLE
FIX -> Preventing the command prompt / input to be overwritten by logs

### DIFF
--- a/shared/logger.py
+++ b/shared/logger.py
@@ -1,5 +1,12 @@
 from dlogger import DLogger
 import asyncio
+import sys
+
+try:
+    import readline
+    HAS_READLINE = True
+except ImportError:
+    HAS_READLINE = False
 
 class Logger(DLogger):
     ICONS = {
@@ -50,7 +57,19 @@ class Logger(DLogger):
         )
 
     def print(self, message: str, style: str = '', icon: str = '', end: str = '\n') -> None:
+        if HAS_READLINE:
+            if sys.stdin.isatty():
+                current_line = readline.get_line_buffer()
+                sys.stdout.write('\r' + ' ' * (len(current_line) + 20) + '\r')
+                sys.stdout.flush()
+        
+
         super().print(message=message, style=style, icon=icon, end=end)
+
+        if HAS_READLINE:
+            if sys.stdin.isatty() and current_line:
+                sys.stdout.write('\033[1;32mbotwave › \033[0m ' + current_line)
+                sys.stdout.flush()
 
         ws_message = f"[{icon}] {message}" if icon else message
 


### PR DESCRIPTION
Previously, the command prompt used to be overwritten by logs:
```sh
botwave ›  asdasda[INFO] Registration attempt from raspberrypi
[OK] Client registered: raspberrypi (raspberrypi_192.168.1.90)
[VER]   Client protocol version: 2.0.1. Some features may not work correctly.
asdas
```
This PR fixes it, by editing logger.py and adding readline usage to prevent it from being overwritten.
Tested for server component, should work the same on the local one.