### PR TITLE
[Feature]: More logging customization

### DIFF
--- a/assets/installation.json
+++ b/assets/installation.json
@@ -134,7 +134,7 @@
     ],
     "requirements": [
       "websockets==11.0.3",
-      "dlogger==1.0.4",
+      "dlogger==1.0.5",
       "aiofiles==0.8.0",
       "aiohttp",
       "morse-talk==0.2",

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -64,9 +64,19 @@ class Logger(DLogger):
     def __init__(self):
         # Initialize with prebuilt icons & styles and ws support.
         
+        show_time = Env.get_bool("LOG_TIME")
+        time_format = Env.get("LOG_TIME_FORMAT", "%Y-%m-%d %H:%M:%S")
+        save_to = Env.get("LOG_FILE")
+        save = True if save_to else False
+
         super().__init__(
             icons=self.ICONS,
-            styles=self.STYLES
+            styles=self.STYLES,
+            show_time=show_time,
+            time_format=time_format,
+            save=save,
+            save_to=save_to,
+            single_file=True
         )
 
     def print(self, message: str, style: str = '', icon: str = '', end: str = '\n') -> None:


### PR DESCRIPTION
This PR adds new environment variables:
- `LOG_FILE`: takes a file path to store the logs to
- `LOG_TIME`: if set to `true`, logs will contain a timestamp attached to them
- `LOG_TIME_FORMAT`: Configure the timestamp format for `LOG_TIME`. Defaults to `%Y-%m-%d %H:%M:%S`

Additionally, `dlogger` was bumped to `1.0.5` (was `1.0.4`)