### PR TITLE
[Feature]: support for transaction ID in commands and logs

### DIFF
--- a/local/local.py
+++ b/local/local.py
@@ -383,6 +383,7 @@ class BotWaveCLI:
                 "BW_HANDLERS_DIR": self.handlers_dir,
                 "BW_WS_PORT": str(self.ws_port) if self.ws_port else "0",
                 "BW_PASSKEY_SET": "true" if self.passkey else "false",
+                "BW_TRANSACTION_ID": Log.transaction_id.get() or "",
             }
         except:
             ...

--- a/local/local.py
+++ b/local/local.py
@@ -123,6 +123,13 @@ class BotWaveCLI:
     def _execute_command(self, command: str, interpolate: bool = True):
         try:
 
+            tx_match = re.search(r'transaction_id=([^\s]+)', command)
+            if tx_match:
+                Log.set_transaction_id(tx_match.group(1))
+                command = re.sub(r'\s*transaction_id=[^\s]+', '', command)
+            else:
+                Log.clear_transaction_id()
+
             if "#" in command:
                 command = command.split("#", 1)[0]
 
@@ -356,6 +363,9 @@ class BotWaveCLI:
         except Exception as e:
             Log.error(f"Error executing command '{command}': {e}")
             return True
+        
+        finally:
+            Log.clear_transaction_id()
         
     def _build_context(self) -> dict:
         ctx = {}

--- a/misc_doc/handlers.md
+++ b/misc_doc/handlers.md
@@ -60,6 +60,7 @@ These variables describe the machine running the handler:
 | `BW_HANDLERS_DIR` | Handlers directory path |
 | `BW_WS_PORT` | WebSocket port (`0` if unset) |
 | `BW_PASSKEY_SET` | `true` or `false` |
+| `BW_TRANSACTION_ID` | User-provided transaction ID or empty |
 | `BW_ARGV{n}` | Every arg value of the last command |
 
 ### Always available (Server Only)

--- a/server/server.py
+++ b/server/server.py
@@ -456,6 +456,14 @@ class BotWaveServer:
 
     def _execute_command(self, command: str, interpolate: bool = True):
         try:
+            
+            tx_match = re.search(r'transaction_id=([^\s]+)', command)
+            if tx_match:
+                Log.set_transaction_id(tx_match.group(1))
+                command = re.sub(r'\s*transaction_id=[^\s]+', '', command)
+            else:
+                Log.clear_transaction_id()
+
             if "#" in command:
                 command = command.split("#", 1)[0]
 

--- a/server/server.py
+++ b/server/server.py
@@ -456,7 +456,7 @@ class BotWaveServer:
 
     def _execute_command(self, command: str, interpolate: bool = True):
         try:
-            
+
             tx_match = re.search(r'transaction_id=([^\s]+)', command)
             if tx_match:
                 Log.set_transaction_id(tx_match.group(1))
@@ -791,6 +791,7 @@ class BotWaveServer:
                 "BW_HANDLERS_DIR": self.handlers_dir,
                 "BW_WS_PORT": str(self.ws_port) if self.ws_port else "0",
                 "BW_PASSKEY_SET": "true" if self.passkey else "false",
+                "BW_TRANSACTION_ID": Log.transaction_id.get() or "",
                 "BW_SERVER_CONNECTED_CLIENTS": ",".join(
                         client.machine_info.get("hostname", "unknown") 
                         for client in self.clients.values()

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -1,5 +1,6 @@
 from dlogger import DLogger
 import asyncio
+import contextvars
 import re
 import sys
 
@@ -69,6 +70,8 @@ class Logger(DLogger):
         save_to = Env.get("LOG_FILE")
         save = True if save_to else False
 
+        self.transaction_id = contextvars.ContextVar('transaction_id', default=None)
+
         super().__init__(
             icons=self.ICONS,
             styles=self.STYLES,
@@ -90,6 +93,9 @@ class Logger(DLogger):
                 sys.stdout.write('\r' + ' ' * (len(current_line) + 20) + '\r')
                 sys.stdout.flush()
 
+        tx_id = self.transaction_id.get()
+        if tx_id:
+            message = f"{message}transaction_id={tx_id}"
 
         if Env.get_bool("REDACT_IPV4"):
             message = self.__redact_ipv4(message)
@@ -116,6 +122,12 @@ class Logger(DLogger):
 
     def __redact_ipv4(self, text: str) -> str:
         return re.sub(r'(?:\d{1,3}\.){3}\d{1,3}', '[REDACTED]', text)
+    
+    def set_transaction_id(self, tx_id: str):
+        self.transaction_id.set(tx_id)
+
+    def clear_transaction_id(self):
+        self.transaction_id.set(None)
 
 def toggle_input(is_active=None):
     global INPUT_ACTIVE
@@ -125,6 +137,5 @@ def toggle_input(is_active=None):
     else:
         INPUT_ACTIVE = bool(is_active)
 
-        
 
 Log = Logger()


### PR DESCRIPTION
Commands now accept a transaction_id=`<value>` parameter. This is mainly aimed at remote scripts that send commands and need to reliably identify which log lines belong to their request. Every log entry produced during that command's execution will carry the same ID, making it trivial to filter out the noise and only grab what's yours.
