### PR TITLE
[Feature]: Added remote command output isolation

### DIFF
--- a/shared/logger.py
+++ b/shared/logger.py
@@ -71,7 +71,8 @@ class Logger(DLogger):
         save = True if save_to else False
 
         self.transaction_id = contextvars.ContextVar('transaction_id', default=None)
-
+        self.remote_cmd_socket = contextvars.ContextVar('remote_cmd_socket', default=None)
+        
         super().__init__(
             icons=self.ICONS,
             styles=self.STYLES,
@@ -109,16 +110,28 @@ class Logger(DLogger):
 
         ws_message = f"[{icon}] {message}" if icon else message
 
-        for ws in list(self.ws_clients):
+        origin_ws = self.remote_cmd_socket.get()
+
+        if Env.get_bool("ISOLATE_REMOTE", True) and origin_ws:
+            # If we want to isolate remote outputs AND the log was triggered
+            # by a remote conn, send it only to the remote conn
             try:
                 if self.ws_loop:
-                    asyncio.run_coroutine_threadsafe(ws.send(ws_message), self.ws_loop)
+                    asyncio.run_coroutine_threadsafe(origin_ws.send(ws_message), self.ws_loop)
             except Exception as e:
                 self.warn(f"Error sending to WebSocket client: {e}")
+        else:
+            # if not, blast it to everyone
+            for ws in list(self.ws_clients):
                 try:
-                    self.ws_clients.discard(ws)
-                except Exception:
-                    pass
+                    if self.ws_loop:
+                        asyncio.run_coroutine_threadsafe(ws.send(ws_message), self.ws_loop)
+                except Exception as e:
+                    self.warn(f"Error sending to WebSocket client: {e}")
+                    try:
+                        self.ws_clients.discard(ws)
+                    except Exception:
+                        pass
 
     def __redact_ipv4(self, text: str) -> str:
         return re.sub(r'(?:\d{1,3}\.){3}\d{1,3}', '[REDACTED]', text)
@@ -128,6 +141,12 @@ class Logger(DLogger):
 
     def clear_transaction_id(self):
         self.transaction_id.set(None)
+
+    def set_remote_cmd(self, socket):
+        self.remote_cmd_socket.set(socket)
+
+    def clear_remote_cmd(self):
+        self.remote_cmd_socket.set(None)
 
 def toggle_input(is_active=None):
     global INPUT_ACTIVE

--- a/shared/ws_cmd.py
+++ b/shared/ws_cmd.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 from typing import Callable, Set, Optional
+import uuid
 import websockets
 
 from shared.env import Env
@@ -94,8 +95,8 @@ class WSCMDH: # WebSocket Command Handler
             
             try:
                 async for message in websocket:
-                    Log.print(f"{message}", 'bright_green', icon=ip)
-                    self._inject_command(message, websocket)
+                    self._inject_command(message, websocket, ip)
+
             except websockets.exceptions.ConnectionClosed:
                 pass  # exit
                 
@@ -113,8 +114,9 @@ class WSCMDH: # WebSocket Command Handler
         await websocket.close()
         await websocket.wait_closed()
     
-    def _inject_command(self, message: str, websocket):
+    def _inject_command(self, message: str, websocket, ip: str):
         def execute():
+            Log.print(f"{message}", 'bright_green', icon=ip)
 
             self.command_history.append(message)
             self.history_index = len(self.command_history)
@@ -137,8 +139,10 @@ class WSCMDH: # WebSocket Command Handler
                     Log.warning(f"Hmmm, you can't do that. ;)")
                     return
 
+            Log.set_remote_cmd(websocket) # Output of the exec cmd will eventually be isolated
             self.command_executor(message, interpolate=False)
-        
+            Log.clear_remote_cmd()
+
         self.ws_loop.call_soon_threadsafe(
             lambda: self.ws_loop.run_in_executor(None, execute)
         )


### PR DESCRIPTION
When a remote client sends a command via WebSocket, the command's output is now sent back only to that client instead of being broadcast to every connected WebSocket. This prevents other connected users from seeing the output of commands they didn't trigger.
Isolation can be toggled via the `ISOLATE_REMOTE` env var (defaults to `true`). If disabled, output goes back to the old broadcast behavior. Everything is still logged to STDOUT and to eventual log files regardless of the state of this env var.