### PR TITLE
[Feature]: Mark commands end when a transaction ID is provided 

### DIFF
--- a/local/local.py
+++ b/local/local.py
@@ -144,11 +144,15 @@ class BotWaveCLI:
                 )
 
             if not command:
+                Log.end()
                 return True
 
-            cmd_parts = shlex.split(command)
+            try:
+                cmd_parts = shlex.split(command)
 
-            if not cmd_parts:
+            except ValueError as e:
+                Log.error(f"Invalid command syntax: {e}")
+                Log.end()
                 return True
             
             self.last_argv = cmd_parts
@@ -158,6 +162,7 @@ class BotWaveCLI:
             if cmd == 'start':
                 if len(cmd_parts) < 2:
                     Log.error("Usage: start <file> [frequency] [loop] [ps] [rt] [pi]")
+                    Log.end()
                     return True
                 
                 file_path = os.path.join(self.upload_dir, cmd_parts[1])
@@ -168,6 +173,7 @@ class BotWaveCLI:
                 pi = cmd_parts[6] if len(cmd_parts) > 6 else Env.get("DEFAULT_PI", "FFFF")
                 self.start_broadcast(file_path, frequency, ps, rt, pi, loop)
                 self.onstart_handlers(context={**self._build_context(), "BW_BROADCAST_FILE": file_path, "BW_BROADCAST_FREQ": str(frequency)})
+                Log.end()
                 return True
             
             if cmd == 'live':
@@ -178,6 +184,7 @@ class BotWaveCLI:
 
                 self.start_live(frequency, ps, rt, pi)
                 self.onstart_handlers(context={**self._build_context(), "BW_BROADCAST_FREQ": str(frequency)})
+                Log.end()
                 return True
 
 
@@ -186,15 +193,18 @@ class BotWaveCLI:
                 self.onstop_handlers(context={**self._build_context(), "BW_BROADCAST_FILE": self.current_file or ""})
                 self.queue.manual_pause()
                 Log.broadcast("Broadcast stopped")
+                Log.end()
                 return True
             
             elif cmd == 'queue':
                 self.queue.parse(' '.join(cmd_parts[1:]))
+                Log.end()
                 return True
             
             elif cmd == 'sstv':
                 if len(cmd_parts) < 2:
                     Log.error("Usage: sstv <image_path> [mode] [output_wav] [frequency] [loop] [ps] [rt] [pi]")
+                    Log.end()
                     return True
 
                 img_path = cmd_parts[1]
@@ -208,6 +218,7 @@ class BotWaveCLI:
 
                 if not os.path.exists(img_path):
                     Log.error(f"Image file {img_path} not found")
+                    Log.end()
                     return True
 
                 Log.sstv(f"Generating SSTV WAV from {img_path} using mode {mode or 'auto'}...")
@@ -215,11 +226,14 @@ class BotWaveCLI:
                 if success:
                     Log.sstv(f"Broadcasting {output_wav} on {frequency} MHz...")
                     self.start_broadcast(output_wav, frequency, ps, rt, pi, loop)
+
+                Log.end()
                 return True
             
             elif cmd == 'morse':
                 if len(cmd_parts) < 2:
                     Log.error("Usage: morse <text|file> [wpm] [frequency] [loop] [ps] [rt] [pi]")
+                    Log.end()
                     return True
 
                 text_source = cmd_parts[1]
@@ -231,6 +245,7 @@ class BotWaveCLI:
                         Log.morse(f"Loaded Morse text from file: {text_source}")
                     except Exception as e:
                         Log.error(f"Failed to read text file: {e}")
+                        Log.end()
                         return True
                 else:
                     text = text_source
@@ -250,32 +265,39 @@ class BotWaveCLI:
                 
                 if not success or not os.path.exists(output_wav):
                     Log.error("Failed to generate Morse WAV")
+                    Log.end()
                     return True
                 
                 Log.morse(f"Broadcasting {output_wav}...")
                 self.start_broadcast(output_wav, frequency, ps, rt, pi, loop)
                 self.onstart_handlers(context={**self._build_context(), "BW_BROADCAST_FILE": output_wav, "BW_BROADCAST_FREQ": str(frequency)})
+                Log.end()
                 return True
             
             elif cmd == 'lf':
                 self.list_files()
+                Log.end()
                 return True
 
             elif cmd == 'rm':
                 if len(cmd_parts) < 2:
                     Log.error("Usage: rm <filename|all>")
+                    Log.end()
                     return True
                 
                 self.remove_file(cmd_parts[1])
+                Log.end()
                 return True
             
             elif cmd == 'upload':
                 if len(cmd_parts) < 2:
                     Log.error("Usage: upload <source>")
+                    Log.end()
                     return True
                 
                 source = cmd_parts[1]
                 self.upload_file(source)
+                Log.end()
                 return True
             
             elif cmd == 'handlers':
@@ -285,64 +307,78 @@ class BotWaveCLI:
                 else:
                     self.handlers_executor.list_handlers()
 
+                Log.end()
                 return True
             
             elif cmd == 'status':
                 self.display_status()
+                Log.end()
                 return True
             
             elif cmd == 'help':
                 self.display_help()
+                Log.end()
                 return True
             
             elif cmd == '<':
                 if len(cmd_parts) < 2:
                     Log.error("Usage: < <shell command>")
+                    Log.end()
                     return True
                 
                 shell_command = ' '.join(cmd_parts[1:])
                 self.run_shell_command(shell_command, env)
 
+                Log.end()
                 return True
             
             elif cmd == '|':
                 if len(cmd_parts) < 2:
                     Log.error("Usage: | <shell command>")
+                    Log.end()
                     return True
                 
                 shell_command = ' '.join(cmd_parts[1:])
                 self.run_pipe_command(shell_command, env)
+                Log.end()
                 return True
             
             elif cmd == 'dl':
                 if len(cmd_parts) < 2:
                     Log.error("Usage: dl <url> [destination]")
+                    Log.end()
                     return True
                 
                 url = cmd_parts[1]
                 dest_name = cmd_parts[2] if len(cmd_parts) > 2 else None
 
                 self.download_file(url, dest_name)
+                Log.end()
                 return True
             
             elif cmd == 'get':
                 if len(cmd_parts) < 2:
                     Log.error("Usage: get <keys|*>")
+                    Log.end()
                     return True
                 
                 self.print_envkeys(cmd_parts[1:])
+                Log.end()
                 return True
             
             elif cmd == 'set':
                 if len(cmd_parts) < 3:
                     Log.error("Usage: set <key> <value> [immutable]")
+                    Log.end()
                     return True
                 
                 self.set_envkey(cmd_parts[1], cmd_parts[2], cmd_parts[3].lower() == 'true' if len(cmd_parts) > 3 else False)
+                Log.end()
                 return True
             
             elif cmd == 'exit':
                 self.stop()
+                Log.end()
                 return False
             
             else:
@@ -354,14 +390,17 @@ class BotWaveCLI:
                         silent=True
                         )
                     
+                    Log.end()
                     return True
                     
                 else:
                     Log.error(f"Unknown command: {cmd}")
+                    Log.end()
                     return True
             
         except Exception as e:
             Log.error(f"Error executing command '{command}': {e}")
+            Log.end()
             return True
         
         finally:

--- a/local/local.py
+++ b/local/local.py
@@ -1058,8 +1058,8 @@ def main():
     check() #from shared.cat
 
     parser = argparse.ArgumentParser(prog="bw-local", description='BotWave Standalone CLI Client')
-    parser.add_argument('--upload-dir', default='/opt/BotWave/uploads/', help='Directory to store uploaded files')
-    parser.add_argument('--handlers-dir', default='/opt/BotWave/handlers/', help='Directory to retrieve l_ handlers from')
+    parser.add_argument('--upload-dir', default=None, help='Directory to store uploaded files')
+    parser.add_argument('--handlers-dir', default=None, help='Directory to retrieve l_ handlers from')
     parser.add_argument('--skip-checks', action=argparse.BooleanOptionalAction, help='Skip system requirements checks')
     parser.add_argument('--daemon', action=argparse.BooleanOptionalAction, help='Run in daemon mode (non-interactive)')
     parser.add_argument('--rc', type=int, default=None, help='Remote CLI port for remote management')

--- a/server/server.py
+++ b/server/server.py
@@ -478,6 +478,7 @@ class BotWaveServer:
                 )
 
             if not command:
+                Log.end()
                 return True
                         
             try:
@@ -485,6 +486,7 @@ class BotWaveServer:
 
             except ValueError as e:
                 Log.error(f"Invalid command syntax: {e}")
+                Log.end()
                 return True
             
             self.last_argv = cmd
@@ -510,6 +512,9 @@ class BotWaveServer:
                     Log.error("Command timeout")
                 except Exception as e:
                     Log.error(f"Command error: {e}")
+                finally:
+                    Log.end()
+                    
             else:
                 Log.error("Server not running")
             

--- a/server/server.py
+++ b/server/server.py
@@ -529,69 +529,93 @@ class BotWaveServer:
         # CLIENT MANAGEMENT 
         elif command_name == 'list':
             self.list_clients()
+            Log.end()
             return
         
         elif command_name == 'kick':
             if len(cmd) < 2:
                 Log.error("Usage: kick <targets> [reason]")
+                Log.end()
                 return
+            
             reason = " ".join(cmd[2:]) if len(cmd) > 2 else "Kicked by administrator"
             await self.kick_client(cmd[1], reason)
+            Log.end()
             return
         
         elif command_name == 'update':
             if len(cmd) < 2:
                 Log.error("Usage: update <targets> [latest|<version>]")
+                Log.end()
                 return
+            
             update_args = ' '.join(cmd[2:]) if len(cmd) > 2 else ''
             await self.send_update(cmd[1], update_args)
+            Log.end()
             return
         
         elif command_name == 'status':
             targets = cmd[1] if len(cmd) > 1 else None
             await self.display_status(targets)
+            Log.end()
             return
         
         # FILE MANAGEMENT 
         elif command_name == 'upload':
             if len(cmd) < 3:
                 Log.error("Usage: upload <targets> <file|folder>")
+                Log.end()
                 return
+            
             await self.upload_file(cmd[1], cmd[2])
+            Log.end()
             return
         
         elif command_name == 'dl':
             if len(cmd) < 3:
                 Log.error("Usage: dl <targets> <url>")
+                Log.end()
                 return
+            
             await self.download_file(cmd[1], cmd[2])
+            Log.end()
             return
         
         elif command_name == 'lf':
             if len(cmd) < 2:
                 Log.error("Usage: lf <targets>")
+                Log.end()
                 return
+            
             await self.list_files(cmd[1])
+            Log.end()
             return
         
         elif command_name == 'rm':
             if len(cmd) < 3:
                 Log.error("Usage: rm <targets> <filename|all>")
+                Log.end()
                 return
+            
             await self.remove_file(cmd[1], cmd[2])
+            Log.end()
             return
         
         elif command_name == 'sync':
             if len(cmd) < 3:
                 Log.error("Usage: sync <targets|folder/> <source_target|folder/>")
+                Log.end()
                 return
+            
             await self.sync_files(cmd[1], cmd[2])
+            Log.end()
             return
         
         # BROADCAST CONTROL 
         elif command_name == 'start':
             if len(cmd) < 3:
                 Log.error("Usage: start <targets> <file> [freq] [loop] [ps] [rt] [pi]")
+                Log.end()
                 return
                 
             frequency = float(cmd[3]) if len(cmd) > 3 else Env.get_int("DEFAULT_FREQ", 90)
@@ -601,11 +625,13 @@ class BotWaveServer:
             pi = cmd[7] if len(cmd) > 7 else Env.get("DEFAULT_PI", "FFFF")
             
             await self.start_broadcast(cmd[1], cmd[2], frequency, ps, rt, pi, loop)
+            Log.end()
             return
 
         elif command_name == 'live':
             if len(cmd) < 2:
                 Log.error("Usage: live <targets> [freq] [ps] [rt] [pi]")
+                Log.end()
                 return
             
             frequency = float(cmd[2]) if len(cmd) > 2 else Env.get_int("DEFAULT_FREQ", 90)
@@ -614,26 +640,31 @@ class BotWaveServer:
             pi = cmd[5] if len(cmd) > 5 else Env.get("DEFAULT_PI", "FFFF")
 
             await self.start_live(cmd[1], frequency, ps, rt, pi)
+            Log.end()
             return
 
         elif command_name == 'stop':
             if len(cmd) < 2:
                 Log.error("Usage: stop <targets>")
+                Log.end()
                 return
             
             self.queue.manual_pause()
             
             await self.stop_broadcast(cmd[1])
+            Log.end()
             return
         
         elif command_name == 'queue':
             self.queue.parse(' '.join(cmd[1:]))
+            Log.end()
             return
         
         # OTHER MEDIA FORM
         elif command_name == 'sstv':
             if len(cmd) < 3:
                 Log.error("Usage: sstv <targets> <image_path> [mode] [output_wav] [freq] [loop] [ps] [rt] [pi]")
+                Log.end()
                 return
             
             targets = cmd[1]
@@ -648,6 +679,7 @@ class BotWaveServer:
             
             if not os.path.exists(img_path):
                 Log.error(f"Image file {img_path} not found")
+                Log.end()
                 return
             
             Log.sstv(f"Generating SSTV WAV from {img_path}...")
@@ -660,12 +692,15 @@ class BotWaveServer:
                 
                 Log.sstv(f"Broadcasting {os.path.basename(output_wav)}...")
                 await self.start_broadcast(targets, os.path.basename(output_wav), frequency, ps, rt, pi, loop)
+            
+            Log.end()
             return
         
         # MORSE
         elif command_name == 'morse':
             if len(cmd) < 3:
                 Log.error("Usage: morse <targets> <text|file> [wpm] [freq] [loop] [ps] [rt] [pi]")
+                Log.end()
                 return
 
             targets = cmd[1]
@@ -698,6 +733,7 @@ class BotWaveServer:
 
             if not success or not os.path.exists(output_wav):
                 Log.error("Failed to generate Morse WAV")
+                Log.end()
                 return
 
             Log.morse(f"Uploading {output_wav} to {targets}...")
@@ -708,26 +744,28 @@ class BotWaveServer:
 
             Log.morse("Broadcasting Morse...")
             await self.start_broadcast(targets, os.path.basename(output_wav), frequency=frequency, ps=ps, rt=rt, pi=pi, loop=loop)
-
+            Log.end()
             return
         
         # ENVIRONMENT
         elif command_name == 'get':
             if len(cmd) < 2:
                 Log.error("Usage: get <keys|*>")
+                Log.end()
                 return
             
             self.print_envkeys(cmd[1:])
-
+            Log.end()
             return
 
         elif command_name == 'set':
             if len(cmd) < 3:
                 Log.error("Usage: set <key> <value> [immutable]")
+                Log.end()
                 return
             
             self.set_envkey(cmd[1], cmd[2], cmd[3].lower() == 'true' if len(cmd) > 3 else False)
-            
+            Log.end()
             return
 
 
@@ -737,28 +775,35 @@ class BotWaveServer:
                 self.handlers_executor.list_handler_commands(cmd[1])
             else:
                 self.handlers_executor.list_handlers()
+
+            Log.end()
             return
         
         elif command_name == '<':
             if len(cmd) < 2:
                 Log.error("Usage: < <shell command>")
+                Log.end()
                 return
             
             shell_command = ' '.join(cmd[1:])
             await self.run_shell_command(shell_command, env)
+            Log.end()
             return
         
         elif command_name == '|':
             if len(cmd) < 2:
                 Log.error("Usage: | <shell command>")
+                Log.end()
                 return
             
             shell_command = ' '.join(cmd[1:])
             await self.run_pipe_command(shell_command, env)
+            Log.end()
             return
         
         elif command_name == 'help':
             self.display_help()
+            Log.end()
             return
         
         else:
@@ -769,10 +814,11 @@ class BotWaveServer:
                     self._build_context(),
                     silent=True
                     )
+                Log.end()
                 
             else:
-
                 Log.error(f"Unknown command: {command_name}")
+                Log.end()
         
 
     def _build_context(self, client_id: str = None) -> dict:

--- a/server/server.py
+++ b/server/server.py
@@ -508,11 +508,13 @@ class BotWaveServer:
                             self.loop
                         )
                         future.result(timeout=300)
+                        
                 except asyncio.TimeoutError:
                     Log.error("Command timeout")
+                    Log.end()
+
                 except Exception as e:
                     Log.error(f"Command error: {e}")
-                finally:
                     Log.end()
                     
             else:

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -133,6 +133,11 @@ class Logger(DLogger):
                     except Exception:
                         pass
 
+    def end(self):
+        # sends "ENDtransaction_id=<tid>" if a transaction_id is set
+        if self.transaction_id.get():
+            self.print("END") # transaction_id will automatically be appended
+
     def __redact_ipv4(self, text: str) -> str:
         return re.sub(r'(?:\d{1,3}\.){3}\d{1,3}', '[REDACTED]', text)
     


### PR DESCRIPTION
When a `transaction_id=<value>` is provided into a command, a `ENDtransaction_id=<value>` will be added at the end of execution, so scripts can easily know when they have to stop listening