### PR TITLE
[Feature]: Implemented resources monitoring during broadcast

### DIFF
--- a/assets/installation.json
+++ b/assets/installation.json
@@ -150,7 +150,8 @@
       "aiofiles==0.8.0",
       "aiohttp",
       "morse-talk==0.2",
-      "pyalsaaudio==0.11.0"
+      "pyalsaaudio==0.11.0",
+      "psutil==7.2.2"
     ],
     "binaries": [
       "bin/bw-autorun",

--- a/client/client.py
+++ b/client/client.py
@@ -657,9 +657,6 @@ class BotWaveClient:
                     finally:
                         self.stream_active = False
 
-                self.broadcasting = True
-                self.current_file = f"stream:{token[:8]}"
-
                 success = self.piwave.play(
                     sync_generator_wrapper(),
                     sample_rate=rate,
@@ -672,6 +669,9 @@ class BotWaveClient:
                 if success:
                     Log.broadcast(f"Broadcasting stream on {frequency} MHz (rate={rate}, channels={channels})")
                     self.broadcast_start_time = time.time()
+                    self.tips.is_broadcasting = True
+                    self.broadcasting = True
+                    self.current_file = f"stream:{token[:8]}"
 
                 else:
                     raise Exception("PiWave returned a non-true status, set talk to true to debug.")
@@ -681,6 +681,7 @@ class BotWaveClient:
             except Exception as e:
                 Log.error(f"Stream broadcast error: {e}")
                 self.broadcasting = False
+                self.tips.is_broadcasting = False
                 self.broadcast_start_time = None
                 return e
 
@@ -730,15 +731,15 @@ class BotWaveClient:
 
                 success = self.piwave.play(file_path, blocking=False)
 
-                self.broadcasting = True
-                self.current_file = filename
-
                 if not loop:
                     self.piwave_monitor.start(self.piwave, finished, asyncio.get_event_loop())
 
                 if success:
                     Log.broadcast(f"Currently broadcasting {filename} on {frequency} MHz")
                     self.broadcast_start_time = time.time()
+                    self.tips.is_broadcasting = True
+                    self.broadcasting = True
+                    self.current_file = filename
 
                 else:
                     raise Exception("PiWave returned a non-true status, set talk to true to debug.")
@@ -749,6 +750,7 @@ class BotWaveClient:
             except Exception as e:
                 Log.error(f"Broadcast error: {e}")
                 self.broadcasting = False
+                self.tips.is_broadcasting = False
                 self.broadcast_start_time = None
                 return e
 
@@ -778,6 +780,7 @@ class BotWaveClient:
                     self.piwave = None
 
             self.broadcasting = False
+            self.tips.is_broadcasting = False
             self.broadcast_start_time = None
             self.current_file = None
 

--- a/shared/tips.py
+++ b/shared/tips.py
@@ -1,12 +1,55 @@
 import errno
 import os
+import psutil
 import tempfile
+import threading
+import time
 
+from shared.env import Env
 from shared.logger import Log
 
 class TipEngine:
     def __init__(self, is_server: bool = True):
+        self.is_broadcasting = False
+        
         self.__lockfile = os.path.join(tempfile.gettempdir(), f"botwave_{'server' if is_server else 'client'}.pid")
+        self.__monitor_thread = None
+        self.__monitor_stop = threading.Event()
+
+    def __monitor_resources(self):
+        poll_interval = Env.get_int("RESOURCE_POLL_INTERVAL", 10) # seconds between each cpu/ram check
+        warn_cooldown = Env.get_int("RESOURCE_WARN_COOLDOWN", 60) # seconds between repeated warnings
+        cpu_threshold = Env.get_int("RESOURCE_CPU_THRESHOLD", 80) # % cpu
+        ram_threshold = Env.get_int("RESOURCE_RAM_THRESHOLD", 90) # % ram
+
+        last_warned_at = 0
+
+        while not self.__monitor_stop.is_set():
+            self.__monitor_stop.wait(poll_interval)
+
+            if self.__monitor_stop.is_set():
+                break
+
+            try:
+                cpu = psutil.cpu_percent(interval=None)  # non-blocking
+                ram = psutil.virtual_memory().percent
+
+                now = time.monotonic()
+                issues = []
+
+                if cpu >= cpu_threshold:
+                    issues.append(f"CPU at {cpu:.0f}% (threshold: {cpu_threshold}%)")
+
+                if ram >= ram_threshold:
+                    issues.append(f"RAM at {ram:.0f}% (threshold: {ram_threshold}%)")
+
+                if issues and self.is_broadcasting and (now - last_warned_at) >= warn_cooldown:
+                    for issue in issues:
+                        Log.warning(f"High resource usage detected: {issue}. Backend may struggle.")
+                    last_warned_at = now
+
+            except Exception:
+                pass  # don't let a psutil hiccup kill the monitor
 
     def __pid_exists(self, pid: int) -> bool:
         if pid <= 0:
@@ -60,7 +103,14 @@ class TipEngine:
         self.__check_lock_conflict()
         self.__write_lockfile()
 
+        psutil.cpu_percent(interval=None) # kick psutil interval sampler
+        self.__monitor_thread = threading.Thread(target=self.__monitor_resources, daemon=True)
+        self.__monitor_thread.start()
+
     def stop(self):
+        self.__monitor_stop.set()
+
+
         if os.path.exists(self.__lockfile):
             try:
                 os.remove(self.__lockfile)

--- a/shared/tips.py
+++ b/shared/tips.py
@@ -15,6 +15,7 @@ class TipEngine:
         self.__lockfile = os.path.join(tempfile.gettempdir(), f"botwave_{'server' if is_server else 'client'}.pid")
         self.__monitor_thread = None
         self.__monitor_stop = threading.Event()
+        self.__is_server = is_server
 
     def __monitor_resources(self):
         poll_interval = Env.get_int("RESOURCE_POLL_INTERVAL", 10) # seconds between each cpu/ram check
@@ -103,13 +104,13 @@ class TipEngine:
         self.__check_lock_conflict()
         self.__write_lockfile()
 
-        psutil.cpu_percent(interval=None) # kick psutil interval sampler
-        self.__monitor_thread = threading.Thread(target=self.__monitor_resources, daemon=True)
-        self.__monitor_thread.start()
+        if not self.__is_server: # monitor resources on clients
+            psutil.cpu_percent(interval=None) # kick psutil interval sampler
+            self.__monitor_thread = threading.Thread(target=self.__monitor_resources, daemon=True)
+            self.__monitor_thread.start()
 
     def stop(self):
         self.__monitor_stop.set()
-
 
         if os.path.exists(self.__lockfile):
             try:


### PR DESCRIPTION
This PR adds a background resource monitor to `TipEngine` (client-only) that watches system CPU and RAM usage using `psutil` and warns when either exceeds a configurable threshold while a broadcast is active, since that's when the backend is under load and most likely to struggle.

New env vars:
- `RESOURCE_POLL_INTERVAL`: how often to check (default: 10s)
- `RESOURCE_WARN_COOLDOWN`: minimum time between repeated warnings (default: 60s)
- `RESOURCE_CPU_THRESHOLD`: CPU % that triggers a warning (default: 80)
- `RESOURCE_RAM_THRESHOLD`: RAM % that triggers a warning (default: 90)
