### PR TITLE
[Feature]: Float support for DEFAULT_FREQ

### DIFF
--- a/local/local.py
+++ b/local/local.py
@@ -166,7 +166,7 @@ class BotWaveCLI:
                     return True
                 
                 file_path = os.path.join(self.upload_dir, cmd_parts[1])
-                frequency = float(cmd_parts[2]) if len(cmd_parts) > 2 else Env.get_int("DEFAULT_FREQ", 90)
+                frequency = float(cmd_parts[2]) if len(cmd_parts) > 2 else Env.get_float("DEFAULT_FREQ", 90)
                 loop = cmd_parts[3].lower() == 'true' if len(cmd_parts) > 3 else False
                 ps = cmd_parts[4] if len(cmd_parts) > 4 else Env.get("DEFAULT_PS", "BotWave")
                 rt = cmd_parts[5] if len(cmd_parts) > 5 else Env.get("DEFAULT_RT", cmd_parts[1])
@@ -177,7 +177,7 @@ class BotWaveCLI:
                 return True
             
             if cmd == 'live':
-                frequency = float(cmd_parts[1]) if len(cmd_parts) > 1 else Env.get_int("DEFAULT_FREQ", 90)
+                frequency = float(cmd_parts[1]) if len(cmd_parts) > 1 else Env.get_float("DEFAULT_FREQ", 90)
                 ps = cmd_parts[2] if len(cmd_parts) > 2 else Env.get("DEFAULT_PS", "BotWave")
                 rt = cmd_parts[3] if len(cmd_parts) > 3 else Env.get("DEFAULT_RT", "Live")  # Fixed index and fallback
                 pi = cmd_parts[4] if len(cmd_parts) > 4 else Env.get("DEFAULT_PI", "FFFF")  # Fixed index
@@ -210,7 +210,7 @@ class BotWaveCLI:
                 img_path = cmd_parts[1]
                 mode = cmd_parts[2] if len(cmd_parts) > 2 else None
                 output_wav = cmd_parts[3] if len(cmd_parts) > 3 else os.path.join(self.upload_dir, os.path.splitext(os.path.basename(img_path))[0] + ".wav")
-                frequency = float(cmd_parts[4]) if len(cmd_parts) > 4 else Env.get_int("DEFAULT_FREQ", 90)
+                frequency = float(cmd_parts[4]) if len(cmd_parts) > 4 else Env.get_float("DEFAULT_FREQ", 90)
                 loop = cmd_parts[5].lower() == 'true' if len(cmd_parts) > 5 else False
                 ps = cmd_parts[6] if len(cmd_parts) > 6 else Env.get("DEFAULT_PS", "BotWave")
                 rt = cmd_parts[7] if len(cmd_parts) > 7 else Env.get("DEFAULT_RT", output_wav)
@@ -252,7 +252,7 @@ class BotWaveCLI:
                 
                 wpm = int(cmd_parts[2]) if len(cmd_parts) > 2 else Env.get_int("DEFAULT_MORSE_WPM", 20)
                 morse_freq = Env.get_int("MORSE_FREQUENCY", 700)
-                frequency = float(cmd_parts[3]) if len(cmd_parts) > 3 else Env.get_int("DEFAULT_FREQ", 90)
+                frequency = float(cmd_parts[3]) if len(cmd_parts) > 3 else Env.get_float("DEFAULT_FREQ", 90)
                 loop = cmd_parts[4].lower() == 'true' if len(cmd_parts) > 4 else False
                 ps = cmd_parts[5] if len(cmd_parts) > 5 else Env.get("DEFAULT_PS", "BotWave")
                 rt = cmd_parts[6] if len(cmd_parts) > 6 else Env.get("DEFAULT_RT", "Morse")

--- a/server/server.py
+++ b/server/server.py
@@ -627,7 +627,7 @@ class BotWaveServer:
                 Log.end()
                 return
                 
-            frequency = float(cmd[3]) if len(cmd) > 3 else Env.get_int("DEFAULT_FREQ", 90)
+            frequency = float(cmd[3]) if len(cmd) > 3 else Env.get_float("DEFAULT_FREQ", 90)
             loop = cmd[4].lower() == 'true' if len(cmd) > 4 else False
             ps = cmd[5] if len(cmd) > 5 else Env.get("DEFAULT_PS", "BotWave")
             rt = cmd[6] if len(cmd) > 6 else Env.get("DEFAULT_RT", cmd[2]) # file name
@@ -643,7 +643,7 @@ class BotWaveServer:
                 Log.end()
                 return
             
-            frequency = float(cmd[2]) if len(cmd) > 2 else Env.get_int("DEFAULT_FREQ", 90)
+            frequency = float(cmd[2]) if len(cmd) > 2 else Env.get_float("DEFAULT_FREQ", 90)
             ps = cmd[3] if len(cmd) > 3 else Env.get("DEFAULT_PS", "BotWave")
             rt = cmd[4] if len(cmd) > 4 else Env.get("DEFAULT_RT", "Broadcasting")
             pi = cmd[5] if len(cmd) > 5 else Env.get("DEFAULT_PI", "FFFF")
@@ -680,7 +680,7 @@ class BotWaveServer:
             img_path = cmd[2]
             mode = cmd[3] if len(cmd) > 3 else None
             output_wav = cmd[4] if len(cmd) > 4 else os.path.join(tempfile.gettempdir(), os.path.splitext(os.path.basename(img_path))[0] + ".wav")
-            frequency = float(cmd[5]) if len(cmd) > 5 else Env.get_int("DEFAULT_FREQ", 90)
+            frequency = float(cmd[5]) if len(cmd) > 5 else Env.get_float("DEFAULT_FREQ", 90)
             loop = cmd[6].lower() == 'true' if len(cmd) > 6 else False
             ps = cmd[7] if len(cmd) > 7 else Env.get("DEFAULT_PS", "BotWave")
             rt = cmd[8] if len(cmd) > 8 else Env.get("DEFAULT_RT", output_wav)
@@ -728,7 +728,7 @@ class BotWaveServer:
 
             wpm = int(cmd[3]) if len(cmd) > 3 else Env.get_int("DEFAULT_MORSE_WPM", 20)
             morse_freq = Env.get_int("MORSE_FREQUENCY", 700)
-            frequency = float(cmd[4]) if len(cmd) > 4 else Env.get_int("DEFAULT_FREQ", 90)
+            frequency = float(cmd[4]) if len(cmd) > 4 else Env.get_float("DEFAULT_FREQ", 90)
             loop = cmd[5].lower() == 'true' if len(cmd) > 5 else False
             ps = cmd[6] if len(cmd) > 6 else Env.get("DEFAULT_PS", "BotWave")
             rt = cmd[7] if len(cmd) > 7 else Env.get("DEFAULT_RT", "Morse")

--- a/shared/env.py
+++ b/shared/env.py
@@ -71,6 +71,17 @@ class EnvManager:
         
         except ValueError:
             return default
+        
+    def get_float(self, key: str, default: float | None = None) -> float | None:
+        """Return the value of a key as a float, or default if missing or invalid."""
+
+        value = self.get(key)
+
+        try:
+            return float(value) if value is not None else default
+        
+        except ValueError:
+            return default
 
     def get_bool(self, key: str, default: bool = False) -> bool:
         """Return the value of a key as a boolean, or default if missing."""


### PR DESCRIPTION
This PR adds float values support for the environment variable `DEFAULT_FREQ`.

Previously, it only allowed integers, therefore limiting the broadcast range to a very limited range of values.