### PR TITLE
[Fix]: Fixed ALSA capture race issues

### DIFF
--- a/local/local.py
+++ b/local/local.py
@@ -750,7 +750,7 @@ class BotWaveCLI:
             self.stop_broadcast()
 
         try:
-            backend_classes["bw_custom"] = BWCustom
+            backend_classes[self.backend_name] = BWCustom
 
             self.piwave = PiWave(
                 frequency=frequency,

--- a/local/local.py
+++ b/local/local.py
@@ -766,10 +766,12 @@ class BotWaveCLI:
 
             self.alsa.start()
 
+            audio_queue = self.alsa.subscribe()
+
             self.current_file = "live_playback"
             self.broadcasting = True
             
-            success = self.piwave.play(self.alsa.audio_generator(), sample_rate=self.alsa.rate, channels=self.alsa.channels, chunk_size=self.alsa.period_size)
+            success = self.piwave.play(self.alsa.audio_generator(audio_queue), sample_rate=self.alsa.rate, channels=self.alsa.channels, chunk_size=self.alsa.period_size)
             
             self.piwave_monitor.start(self.piwave, finished)
 

--- a/server/server.py
+++ b/server/server.py
@@ -1597,8 +1597,6 @@ class BotWaveServer:
 
     async def stop_broadcast(self, client_targets: str):
 
-        self.alsa.stop()
-
         target_clients = self._parse_client_targets(client_targets)
         
         if not target_clients:
@@ -1634,6 +1632,7 @@ class BotWaveServer:
         Log.print("")        
         Log.info(f"Success: {len(results['stopped'])}, Failure: {len(results['failed'])}")
 
+        self.alsa.stop()
         self.onstop_handlers()
         return len(results['stopped']) > 0
 

--- a/server/server.py
+++ b/server/server.py
@@ -1163,8 +1163,8 @@ class BotWaveServer:
             
             client = self.clients[client_id]
             
-            token = self.http_server.create_stream_token(self.alsa.audio_generator(), self.alsa.rate, self.alsa.channels)
-
+            client_queue = self.alsa.subscribe()
+            token = self.http_server.create_stream_token(self.alsa.audio_generator(client_queue), self.alsa.rate, self.alsa.channels)
             try:
                 response = await client.proto.send(
                     Commands.STREAM_TOKEN,

--- a/shared/alsa.py
+++ b/shared/alsa.py
@@ -1,3 +1,5 @@
+import threading
+import queue
 import time
 
 try:
@@ -13,6 +15,9 @@ class Alsa:
     def __init__(self):
         self.capture = None
         self._running = False
+        self._subscribers = []
+        self._sub_lock = threading.Lock()
+        self._reader_thread = None
 
     @property
     def device_name(self):
@@ -51,7 +56,7 @@ class Alsa:
 
     def start(self):
         """
-        Initializes the ALSA capture interface
+        Initializes the ALSA capture interface and starts the single reader thread
         """
         if not ALSA_AVAILABLE:
             return False
@@ -70,6 +75,8 @@ class Alsa:
                 periodsize=self.period_size
             )
             self._running = True
+            self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
+            self._reader_thread.start()
             return True
         
         except alsaaudio.ALSAAudioError:
@@ -77,39 +84,81 @@ class Alsa:
             Log.alsa("Has the loopback device been set up correctly ?")
             return False
 
-    def audio_generator(self):
+    def _read_loop(self):
         """
-        Generator that yields raw PCM data.
-        It blocks when no audio is playing from the source
+        Single thread that does all the capture.read() calls and fans the
+        data out to every subscriber. Stops clients from fighting over reads.
         """
-        if not ALSA_AVAILABLE:
-            return False
-
-        if not self.capture:
-            Log.alsa("Error: Capture not started.")
-            return
-
         while self._running:
             try:
                 # read() blocks until period_size samples are available
                 length, data = self.capture.read()
                 if length > 0:
-                    yield data
+                    with self._sub_lock:
+                        for q in self._subscribers:
+                            try:
+                                q.put_nowait(data)
+                            except queue.Full:
+                                # client too slow, drop oldest instead of stalling the rest
+                                try:
+                                    q.get_nowait()
+                                except queue.Empty:
+                                    pass
+                                try:
+                                    q.put_nowait(data)
+                                except queue.Full:
+                                    pass
             except alsaaudio.ALSAAudioError:
                 # Xruns
                 continue
             except Exception:
                 break
 
+    def subscribe(self):
+        """
+        Registers a new client, returns the queue it'll receive audio on
+        """
+        q = queue.Queue(maxsize=50)
+        with self._sub_lock:
+            self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q):
+        with self._sub_lock:
+            if q in self._subscribers:
+                self._subscribers.remove(q)
+
+    def audio_generator(self, q):
+        """
+        Generator that yields raw PCM data for one subscriber.
+        It blocks when no audio is available yet.
+        """
+        if not ALSA_AVAILABLE:
+            return False
+
+        while self._running:
+            try:
+                yield q.get(timeout=1)
+            except queue.Empty:
+                continue
+
     def stop(self):
         """
-        Stops the generator loop and releases the ALSA device.
+        Stops the reader thread, drops all subscribers, and releases the ALSA device.
         """
 
         if not ALSA_AVAILABLE:
             return False
         
         self._running = False
+
+        if self._reader_thread:
+            self._reader_thread.join(timeout=1)
+            self._reader_thread = None
+
+        with self._sub_lock:
+            self._subscribers.clear()
+
         if self.capture:
             time.sleep(0.1) # wait gen loop
             self.capture.close()


### PR DESCRIPTION
Multiple clients running `live` at once were each getting their own generator calling `capture.read()` directly on the same ALSA handle. Since reads advance the device's buffer position, concurrent reads from different threads split the stream between clients instead of duplicating it, so everyone got a partial, out-of-order slice of the audio, hence the stuttering, and it got worse the more clients joined.

Fixed by turning `Alsa` into a publisher/subscriber system: a single background thread does all the `capture.read()` calls and pushes each chunk into a queue per subscriber, so every client gets the full stream instead of fighting over frames. `audio_generator()` now reads from a queue instead of the device directly. Updated `start_live` in both `server.py` and `local.py` to subscribe and pass the queue in accordingly.