### PR TITLE
[Fix]: No more client stalling

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -69,6 +69,7 @@ class BotWaveClient:
         self.alsa = Alsa()
         self.stream_task = None
         self.stream_active = False
+        self.feed_task = None
 
         # states
         self.running = False
@@ -638,7 +639,14 @@ class BotWaveClient:
                     finally:
                         stream_queue.put(None)  # sentinel
 
-                asyncio.get_event_loop().create_task(_feed_queue())
+                if self.feed_task and not self.feed_task.done():
+                    self.feed_task.cancel()
+                    try:
+                        await self.feed_task
+                    except asyncio.CancelledError:
+                        pass
+
+                self.feed_task = asyncio.get_event_loop().create_task(_feed_queue())
 
                 def sync_generator_wrapper():
                     try:
@@ -762,6 +770,15 @@ class BotWaveClient:
                 self.stream_active = False
                 await asyncio.sleep(0.2)
 
+            if self.feed_task and not self.feed_task.done():
+                self.feed_task.cancel()
+                try:
+                    await self.feed_task
+                except Exception:
+                    pass
+                finally:
+                    self.feed_task = None
+
             if self.stream_task:
                 try:
                     self.stream_task = None
@@ -770,6 +787,7 @@ class BotWaveClient:
                     Log.error(f"Error closing stream: {e}")
                 finally:
                     self.stream_task = None
+
 
             if self.piwave:
                 try:

--- a/shared/alsa.py
+++ b/shared/alsa.py
@@ -63,7 +63,7 @@ class Alsa:
 
         try:
             if self._running:
-                self.stop()
+                return True
 
             self.capture = alsaaudio.PCM(
                 type=alsaaudio.PCM_CAPTURE,

--- a/shared/http.py
+++ b/shared/http.py
@@ -242,7 +242,7 @@ class BWHTTPFileServer:
                         await response.write(pcm_chunk)
                         await response.drain()
                     except (ConnectionResetError, BrokenPipeError):
-                        Log.server("Client disconnected from PCM stream (connection lost)")
+                        Log.server("Client disconnected from PCM stream")
                         break
                 
                 if request.transport is None or request.transport.is_closing():


### PR DESCRIPTION
Fixes #78

When `live` was called a second time, `alsa.start()` was tearing down and restarting the ALSA device, which killed all subscriber queues. On top of that, the `_feed_queue` coroutine of `bw-client` from the previous stream was left running with no way to cancel it, causing it to starve or corrupt the new stream's queue, resulting in a queue timeout and stall a few seconds in.

- `Alsa.start()` now returns `True` if already running without restarting, keeping the device alive across multiple `live` calls (server)
- `feed_task` is now tracked as a field and cancelled cleanly on every `_stop_broadcast`, before `stream_task` is cleared (client)