### PR TITLE
[Feature]: Replace readline with prompt_toolkit for command input and hints

### DIFF
--- a/assets/installation.json
+++ b/assets/installation.json
@@ -153,6 +153,7 @@
       "shared/http.py",
       "shared/logger.py",
       "shared/morser.py",
+      "shared/prompt.py",
       "shared/protocol.py",
       "shared/protomanager.py",
       "shared/queue.py",
@@ -171,7 +172,8 @@
       "aiohttp",
       "morse-talk==0.2",
       "pyalsaaudio==0.11.0",
-      "psutil==7.2.2"
+      "psutil==7.2.2",
+      "prompt_toolkit==3.0.52"
     ],
     "binaries": [
       "bin/bw-autorun",

--- a/local/local.py
+++ b/local/local.py
@@ -967,7 +967,7 @@ class BotWaveCLI:
         Log.print("    rm broadcast.wav", "cyan")
         Log.print("")
 
-        Log.print("upload <targets> <file|folder>", "bright_green")
+        Log.print("upload <file|folder>", "bright_green")
         Log.print("  Upload a file or folder to the upload directory", "white")
         Log.print("  Examples:", "white")
         Log.print("    upload broadcast.wav", "cyan")

--- a/local/local.py
+++ b/local/local.py
@@ -13,6 +13,8 @@
 import argparse
 import os
 from pathlib import Path
+from prompt_toolkit.formatted_text import ANSI
+from prompt_toolkit.patch_stdout import patch_stdout
 import uuid
 import re
 import signal
@@ -34,8 +36,9 @@ from shared.converter import Converter, ConvertError, SUPPORTED_EXTENSIONS
 from shared.custom_cmds import CCMD
 from shared.env import Env
 from shared.handlers import HandlerExecutor
-from shared.logger import Log, toggle_input
+from shared.logger import Log
 from shared.morser import text_to_morse
+from shared.prompt import get_prompt
 from shared.protocol import PROTOCOL_VERSION
 from shared.pw_monitor import PWM
 from shared.queue import Queue
@@ -44,12 +47,6 @@ from shared.sstv import make_sstv_wav
 from shared.syscheck import check_requirements
 from shared.tips import TipEngine
 from shared.ws_cmd import WSCMDH
-
-try:
-    import readline
-    HAS_READLINE = True
-except:
-    HAS_READLINE = False
 
 try:
     from piwave import PiWave
@@ -1109,52 +1106,36 @@ def main():
     cli.onready_handlers(Env.get("HANDLERS_DIR"))
 
     if not Env.get_bool("DAEMON"):
-        if HAS_READLINE:
-            readline.parse_and_bind('tab: complete')
-            readline.parse_and_bind('set editing-mode emacs')
-            readline.set_history_length(1000)
-            try:
-                readline.read_history_file(Env.get("HISTORY_PATH"))
-            except:
-                pass
 
-        while cli.running:
-            try:
-                print()
-                toggle_input(True)
-                cmd_input = input(f"\033[1;32m{Env.get('PROMPT_TEXT')}\033[0m").strip()
-                toggle_input(False)
+        prompt = get_prompt(history_path=Env.get("HISTORY_PATH", "/opt/BotWave/.history"), is_server=False)
 
-                if not cmd_input:
-                    continue
+        with patch_stdout(raw=True):
+            Log._stream = sys.stdout
 
-                if HAS_READLINE:
-                    readline.add_history(cmd_input)
+            while cli.running:
+                try:
+                    print()
+                    cmd_input = prompt.prompt(ANSI(f"\033[1;32m{Env.get('PROMPT_TEXT')}\033[0m")).strip()
 
-                exit = cli._execute_command(cmd_input)
+                    if not cmd_input:
+                        continue
 
-                if not exit:
+                    exit = cli._execute_command(cmd_input)
+
+                    if not exit:
+                        break
+
+                except KeyboardInterrupt:
+                    Log.warning("Use 'exit' to exit")
+
+                except EOFError:
+                    Log.info("Exiting...")
+                    cli.stop()
                     break
 
-            except KeyboardInterrupt:
-                toggle_input(False)
-                Log.warning("Use 'exit' to exit")
+                except Exception as e:
+                    Log.error(f"Error: {e}")
 
-            except EOFError:
-                toggle_input(False)
-                Log.info("Exiting...")
-                cli.stop()
-                break
-
-            except Exception as e:
-                toggle_input(False)
-                Log.error(f"Error: {e}")
-
-        if HAS_READLINE:
-            try:
-                readline.write_history_file(Env.get("HISTORY_PATH"))
-            except:
-                pass
     else:
         Log.info("Running in daemon mode. Local client will continue to run in the background.")
         try:

--- a/server/server.py
+++ b/server/server.py
@@ -1936,10 +1936,10 @@ class BotWaveServer:
         Log.print("    live all", "cyan")
         Log.print("")
 
-        Log.print("sstv <image_path> [mode] [output_wav] [frequency] [loop] [ps] [rt] [pi]", "bright_green")
+        Log.print("sstv <targets> <image_path> [mode] [output_wav] [frequency] [loop] [ps] [rt] [pi]", "bright_green")
         Log.print("  Convert an image into a SSTV WAV file, and then broadcast it", "white")
         Log.print("  Example:", "white")
-        Log.print("    sstv /path/to/mycat.png Robot36 cat.wav 90 false PsPs Cutie FFFF", "cyan")
+        Log.print("    sstv all /path/to/mycat.png Robot36 cat.wav 90 false PsPs Cutie FFFF", "cyan")
         Log.print("")
 
         Log.print("morse <targets> <text|file> [wpm] [freq] [loop] [ps] [rt] [pi]", "bright_green")

--- a/server/server.py
+++ b/server/server.py
@@ -1910,7 +1910,7 @@ class BotWaveServer:
         Log.print("    list", "cyan")
         Log.print("")
 
-        Log.print("start <targets> <file> [loop] [freq] [ps] [rt] [pi]", "bright_green")
+        Log.print("start <targets> <file> [freq] [loop] [ps] [rt] [pi]", "bright_green")
         Log.print("  Start broadcasting on client(s)", "white")
         Log.print("  Example:", "white")
         Log.print("    start all broadcast.wav 100.5 MyRadio", "cyan")

--- a/server/server.py
+++ b/server/server.py
@@ -49,12 +49,6 @@ from shared.tls import gen_cert, save_cert
 from shared.version import check_for_updates, versions_compatible
 from shared.ws_cmd import WSCMDH
 
-try:
-    import readline
-    HAS_READLINE = True
-except:
-    HAS_READLINE = False
-
 class BotWaveClient:
     def __init__(self, client_id: str, websocket, machine_info: dict, protocol_version: str):
         self.client_id = client_id

--- a/server/server.py
+++ b/server/server.py
@@ -13,6 +13,8 @@ import asyncio
 from datetime import datetime, timezone
 import json
 import os
+from prompt_toolkit.formatted_text import ANSI
+from prompt_toolkit.patch_stdout import patch_stdout
 import re
 import shlex
 import sys
@@ -33,8 +35,9 @@ from shared.custom_cmds import CCMD
 from shared.env import Env
 from shared.handlers import HandlerExecutor
 from shared.http import BWHTTPFileServer
-from shared.logger import Log, toggle_input
+from shared.logger import Log
 from shared.morser import text_to_morse
+from shared.prompt import get_prompt
 from shared.protocol import ProtocolParser, Commands, PROTOCOL_VERSION
 from shared.protomanager import ProtoManager
 from shared.queue import Queue
@@ -2166,53 +2169,36 @@ def main():
             Log.print("+------------------------------------------------------------+", style)
 
             sys.exit(1)
-
-        if HAS_READLINE:
-            readline.parse_and_bind('tab: complete')
-            readline.parse_and_bind('set editing-mode emacs')
-            readline.set_history_length(1000)
-            try:
-                readline.read_history_file(Env.get("HISTORY_PATH", "/opt/BotWave/.history"))
-            except:
-                pass
         
         Log.print("Type 'help' for commands", 'bright_yellow')
         
-        try:            
-            while server.running:
-                try:
-                    print()
-                    toggle_input(True)
-                    cmd_input = input(f'\033[1;32m{Env.get("PROMPT_TEXT", "botwave › ")}\033[0m').strip()
-                    toggle_input(False)
-                    
-                    if not cmd_input:
-                        continue
-                    
-                    if HAS_READLINE:
-                        readline.add_history(cmd_input)
+        prompt = get_prompt(history_path=Env.get("HISTORY_PATH", "/opt/BotWave/.history"), is_server=True)
 
-                    server._execute_command(cmd_input)
-                    
-                except KeyboardInterrupt:
-                    toggle_input(False)
-                    Log.warning("Use 'exit' to exit")
+        try:
+            with patch_stdout(raw=True):
+                Log._stream = sys.stdout # messy but there isn't really another option
 
-                except EOFError:
-                    toggle_input(False)
-                    Log.info("Exiting...")
-                    server.loop.create_task(server.stop())
+                while server.running:
+                    try:
+                        print()
+                        cmd_input = prompt.prompt(ANSI(f'\033[1;32m{Env.get("PROMPT_TEXT", "botwave › ")}\033[0m')).strip()
+                        
+                        if not cmd_input:
+                            continue
 
-                except Exception as e:
-                    toggle_input(False)
-                    Log.error(f"Error: {e}")
+                        server._execute_command(cmd_input)
+                        
+                    except KeyboardInterrupt:
+                        Log.warning("Use 'exit' to exit")
+
+                    except EOFError:
+                        Log.info("Exiting...")
+                        server.loop.create_task(server.stop())
+
+                    except Exception as e:
+                        Log.error(f"Error: {e}")
 
         finally:
-            if HAS_READLINE:
-                try:
-                    readline.write_history_file(Env.get("HISTORY_PATH", "/opt/BotWave/.history"))
-                except:
-                    pass
             server.running = False
 
 if __name__ == "__main__":

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -2,15 +2,8 @@ from dlogger import DLogger
 import asyncio
 import contextvars
 import re
-import sys
 
 from shared.env import Env
-
-try:
-    import readline
-    HAS_READLINE = True
-except ImportError:
-    HAS_READLINE = False
 
 INPUT_ACTIVE = False
 
@@ -84,16 +77,6 @@ class Logger(DLogger):
         )
 
     def print(self, message: str, style: str = '', icon: str = '', end: str = '\n') -> None:
-        has_tty = HAS_READLINE and sys.stdin.isatty()
-        #print(INPUT_ACTIVE)
-
-        if has_tty:
-            current_line = readline.get_line_buffer()
-
-            if INPUT_ACTIVE:
-                sys.stdout.write('\r' + ' ' * (len(current_line) + 20) + '\r')
-                sys.stdout.flush()
-
         tx_id = self.transaction_id.get()
         if tx_id:
             message = f"{message}transaction_id={tx_id}"
@@ -103,25 +86,16 @@ class Logger(DLogger):
 
         super().print(message=message, style=style, icon=icon, end=end)
 
-        if has_tty and INPUT_ACTIVE:
-            prompt = f'\033[1;32m{Env.get("PROMPT_TEXT", "botwave › ")}\033[0m'
-            sys.stdout.write(prompt + current_line)
-            sys.stdout.flush()
-
         ws_message = f"[{icon}] {message}" if icon else message
-
         origin_ws = self.remote_cmd_socket.get()
 
         if Env.get_bool("ISOLATE_REMOTE", True) and origin_ws:
-            # If we want to isolate remote outputs AND the log was triggered
-            # by a remote conn, send it only to the remote conn
             try:
                 if self.ws_loop:
                     asyncio.run_coroutine_threadsafe(origin_ws.send(ws_message), self.ws_loop)
             except Exception as e:
                 self.warn(f"Error sending to WebSocket client: {e}")
         else:
-            # if not, blast it to everyone
             for ws in list(self.ws_clients):
                 try:
                     if self.ws_loop:

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -5,8 +5,6 @@ import re
 
 from shared.env import Env
 
-INPUT_ACTIVE = False
-
 class Logger(DLogger):
     ICONS = {
         'success': 'OK',
@@ -126,14 +124,6 @@ class Logger(DLogger):
 
     def clear_remote_cmd(self):
         self.remote_cmd_socket.set(None)
-
-def toggle_input(is_active=None):
-    global INPUT_ACTIVE
-
-    if is_active is None:
-        INPUT_ACTIVE = not INPUT_ACTIVE
-    else:
-        INPUT_ACTIVE = bool(is_active)
 
 
 Log = Logger()

--- a/shared/prompt.py
+++ b/shared/prompt.py
@@ -19,7 +19,7 @@ class Command():
     
     def process_syntax(self):
         if self.__targets:
-            self.__syntax = f"<targets> {self.__syntax}"
+            self.__syntax = f"<targets> {self.__syntax}".strip()
 
 class SyntaxSuggester(AutoSuggest):
     def __init__(self, commands: dict):
@@ -147,7 +147,6 @@ COMMANDS = {
 def get_prompt(history_path: str, is_server: bool = True):
 
     commands = {}
-
     commands.update(COMMANDS["always"])
         
     if not is_server:

--- a/shared/prompt.py
+++ b/shared/prompt.py
@@ -1,0 +1,175 @@
+from prompt_toolkit import PromptSession
+from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
+from prompt_toolkit.history import FileHistory, InMemoryHistory
+from prompt_toolkit.validation import Validator, ValidationError
+import shlex
+
+
+# commands are split into "server", "local", and "always" categories.
+# server commands that need `<targets>` as a first arg need to have `targets=True`
+# and no string in their syntax 
+class Command():
+    def __init__(self, syntax: str, targets: bool = False):
+        self.__syntax = syntax
+        self.__targets = targets
+    
+    @property
+    def syntax(self):
+        return self.__syntax
+    
+    def process_syntax(self):
+        if self.__targets:
+            self.__syntax = f"<targets> {self.__syntax}"
+
+class SyntaxSuggester(AutoSuggest):
+    def __init__(self, commands: dict):
+        self.commands = commands
+        super().__init__()
+
+    def get_suggestion(self, buffer, document):
+        text = document.text
+        if not text:
+            return None
+        
+        # no space yet = still typing the command name itself
+        curr_text = text.lstrip()
+        if " " not in curr_text and curr_text not in self.commands:
+            matches = [name for name in self.commands if name.startswith(text)]
+            if not matches:
+                return None
+            
+            best = min(matches)
+            return Suggestion(best[len(text):])
+
+        try:
+            parts = shlex.split(text)
+            in_open_quote = False
+
+        except ValueError:
+            # probably an unclosed quote, try fixing it
+            last_quote_idx = max(text.rfind('"'), text.rfind("'"))
+            parseable = text[:last_quote_idx]
+
+            try:
+                parts = shlex.split(parseable)
+
+            except ValueError:
+                return None  #  give up
+            
+            in_open_quote = True
+
+        if not parts:
+            return None
+
+        cmd = parts[0]
+        if cmd not in self.commands:
+            return None
+
+        syntax_parts = self.commands[cmd].syntax.split(" ") if self.commands[cmd].syntax else []
+        typed_args = parts[1:]
+
+        remaining = syntax_parts[len(typed_args) if not in_open_quote else len(typed_args) + 1 :]
+
+        if not remaining:
+            return None
+
+        return Suggestion(" " + " ".join(remaining))
+
+class CommandValidator(Validator):
+    def __init__(self, commands: dict):
+        self.commands = commands
+        super().__init__()
+
+    def validate(self, document):
+        text = document.text
+        if not text:
+            return
+
+        try:
+            parts = shlex.split(text)
+        
+        except ValueError:
+            raise ValidationError(
+                message=f"command is not properly formatted",
+                cursor_position=len(text)
+            )
+        
+
+        cmd = parts[0]
+
+        if cmd not in self.commands:
+            return
+
+        syntax_parts = self.commands[cmd].syntax.split(" ") if self.commands[cmd].syntax else []
+        typed_args = parts[1:]
+
+        required = [p for p in syntax_parts if not p.startswith("[")]
+
+        if len(typed_args) < len(required):
+            missing = required[len(typed_args):]
+            raise ValidationError(
+                message=f"missing required values: {' '.join(missing)}",
+                cursor_position=len(text)
+            )
+
+COMMANDS = {
+    "server": {
+        "list": Command(syntax=""),
+        "sync": Command(syntax="<targets|folder/> <source_target|folder/>"),
+        "kick": Command(syntax="[reason]", targets=True),
+        "update": Command(syntax="[latest|<version>]", targets=True),
+        "status": Command(syntax="[targets]") # targets are optional, so it needs to be taken apart
+    },
+    "local": {
+        "status": Command(syntax="")
+    },
+    "always": {
+        "start": Command(syntax="<file> [loop] [freq] [ps] [rt] [pi]", targets=True),
+        "stop": Command(syntax="", targets=True),
+        "queue": Command(syntax="queue [+|-|*|!|?]"),
+        "live": Command(syntax="[freq] [ps] [rt] [pi]", targets=True),
+        "sstv": Command(syntax="<image_path> [mode] [output_wav] [frequency] [loop] [ps] [rt] [pi]", targets=True),
+        "morse": Command(syntax="<text|file> [wpm] [freq] [loop] [ps] [rt] [pi]", targets=True),
+        "upload": Command(syntax="<file|folder>", targets=True),
+        "dl": Command(syntax="<url>", targets=True),
+        "lf": Command(syntax="", targets=True),
+        "rm": Command(syntax="<filename|all>", targets=True),
+        "handlers": Command(syntax="[filename]"),
+        "<": Command(syntax="<command>"),
+        "|": Command(syntax="<command>"),
+        "get": Command(syntax="<keys|*>"),
+        "set": Command(syntax="<key> <value> [immutable]"),
+        "exit": Command(syntax=""),
+        "help": Command(syntax="")
+    }
+}
+
+def get_prompt(history_path: str, is_server: bool = True):
+
+    commands = {}
+
+    commands.update(COMMANDS["always"])
+        
+    if not is_server:
+        commands.update(COMMANDS["local"])
+
+    else:
+        commands.update(COMMANDS["server"])
+
+        for name, cmd in commands.items():
+            cmd.process_syntax()
+
+    try:
+        history = FileHistory(history_path)
+        list(history.load_history_strings()) # dont load (and crash) later on
+
+    except (OSError, PermissionError):
+        history = InMemoryHistory()
+
+    return PromptSession(
+        auto_suggest=SyntaxSuggester(commands=commands),
+        validator=CommandValidator(commands=commands),
+        validate_while_typing=False,
+        history=history
+    )
+

--- a/shared/prompt.py
+++ b/shared/prompt.py
@@ -124,7 +124,7 @@ COMMANDS = {
         "status": Command(syntax="")
     },
     "always": {
-        "start": Command(syntax="<file> [loop] [freq] [ps] [rt] [pi]", targets=True),
+        "start": Command(syntax="<file> [freq] [loop] [ps] [rt] [pi]", targets=True),
         "stop": Command(syntax="", targets=True),
         "queue": Command(syntax="queue [+|-|*|!|?]"),
         "live": Command(syntax="[freq] [ps] [rt] [pi]", targets=True),


### PR DESCRIPTION
Swaps `input()` + `readline` for `prompt_toolkit` in bw-local and bw-server. Also drops the manual log/prompt-redraw logic in `logger.py` in favor of prompt_toolkit's `patch_stdout`.

Additionally, the prompt now displays 2-steps hints:
- first hint for the command name, starting to write `se` will suggest `set`
- second hint for the command syntax, writing `set` will then show `<key> <value> [immutable]` as an hint.

Command history and validation has also been reimplemented, and fixed minor help bugs.