### PR TITLE
[Feature]: Add release-version update checking alongside protocol checks

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -41,7 +41,7 @@ from shared.security import PathValidator, SecurityError
 from shared.socket import BWWebSocketClient
 from shared.syscheck import check_requirements
 from shared.tips import TipEngine
-from shared.version import check_for_updates
+from shared.version import check_for_updates, check_for_release_updates, get_release_version
 
 
 try:
@@ -211,13 +211,11 @@ class BotWaveClient:
 
                 if os.path.exists(update_flag):
                     try:
-                        release_file = "/opt/BotWave/last_release"
-                        if os.path.exists(release_file):
-                            with open(release_file, "r") as f:
-                                ver = f.read().strip()
+                        new_version = get_release_version()
 
-                            message = f"Updated to {ver}"
-
+                        if new_version:
+                            message = f"Updated to {new_version}"
+                            
                         else:
                             message = "Updated successfully"
 
@@ -975,15 +973,22 @@ def main():
 
     if not Env.get_bool("SKIP_CHECKS"):
         check_requirements()
-        Log.info("Checking for protocol updates...")
-
+        Log.info("Checking for software updates...")
+        
         try:
-            latest_version = check_for_updates()
-            if latest_version:
-                Log.update(f"Update available! Latest version: {latest_version}")
-                Log.update("Consider updating to the latest version by running 'bw-update' in your shell.")
+            latest_proto_ver = check_for_updates()
+            latest_ver = check_for_release_updates()
+
+            if latest_proto_ver:
+                Log.update(f"A protocol update is available. Latest version: {latest_proto_ver}")
+                Log.update("It is recommended updating to the latest version by running 'bw-update' in your shell")
+
+            elif latest_ver:
+                Log.update(f"A newer version of BotWave is available ({latest_ver})")
+                Log.update(f"Update by running 'bw-update --to {latest_ver}' in your shell")
+
             else:
-                Log.success("You are using the latest protocol version")
+                Log.success("You are using the latest version")
 
         except Exception as e:
             Log.warning("Unable to check for updates (continuing anyway)")

--- a/client/client.py
+++ b/client/client.py
@@ -41,7 +41,7 @@ from shared.security import PathValidator, SecurityError
 from shared.socket import BWWebSocketClient
 from shared.syscheck import check_requirements
 from shared.tips import TipEngine
-from shared.version import check_for_updates, check_for_release_updates, get_release_version
+from shared.version import check_for_updates, get_release_version
 
 
 try:
@@ -976,8 +976,7 @@ def main():
         Log.info("Checking for software updates...")
         
         try:
-            latest_proto_ver = check_for_updates()
-            latest_ver = check_for_release_updates()
+            latest_proto_ver, latest_ver = check_for_updates()
 
             if latest_proto_ver:
                 Log.update(f"A protocol update is available. Latest version: {latest_proto_ver}")

--- a/local/local.py
+++ b/local/local.py
@@ -46,6 +46,7 @@ from shared.security import PathValidator, SecurityError
 from shared.sstv import make_sstv_wav
 from shared.syscheck import check_requirements
 from shared.tips import TipEngine
+from shared.version import check_for_release_updates
 from shared.ws_cmd import WSCMDH
 
 try:
@@ -1056,6 +1057,22 @@ class BotWaveCLI:
 
         Log.client("Client stopped")
 
+def _check_updates():
+    Log.info("Checking for software updates...")
+
+    try:
+        latest_ver = check_for_release_updates()
+
+        if latest_ver:
+            Log.update(f"A newer version of BotWave is available ({latest_ver})")
+            Log.update(f"Update by running 'bw-update --to {latest_ver}' in your shell")
+
+        else:
+            Log.success("You are using the latest version")
+
+    except Exception as e:
+        Log.warning("Unable to check for updates (continuing anyway)")
+
 def main():
     Log.header("BotWave Local Client")
 
@@ -1093,7 +1110,9 @@ def main():
     set_prio("PASSKEY", args.pk, None, immutable=True)
     set_prio("REMOTE_CMD_PORT", args.rc, None, immutable=True)
 
-    check_requirements(Env.get_bool("SKIP_CHECKS"))
+    if not Env.get_bool("SKIP_CHECKS"):
+        check_requirements()
+        _check_updates()
 
     cli = BotWaveCLI()
     cli._setup_signal_handlers()

--- a/local/local.py
+++ b/local/local.py
@@ -46,7 +46,7 @@ from shared.security import PathValidator, SecurityError
 from shared.sstv import make_sstv_wav
 from shared.syscheck import check_requirements
 from shared.tips import TipEngine
-from shared.version import check_for_release_updates
+from shared.version import check_for_updates
 from shared.ws_cmd import WSCMDH
 
 try:
@@ -1061,7 +1061,7 @@ def _check_updates():
     Log.info("Checking for software updates...")
 
     try:
-        latest_ver = check_for_release_updates()
+        _, latest_ver = check_for_updates()
 
         if latest_ver:
             Log.update(f"A newer version of BotWave is available ({latest_ver})")

--- a/server/server.py
+++ b/server/server.py
@@ -46,7 +46,7 @@ from shared.socket import BWWebSocketServer
 from shared.sstv import make_sstv_wav
 from shared.tips import TipEngine
 from shared.tls import gen_cert, save_cert
-from shared.version import check_for_updates, versions_compatible, check_for_release_updates
+from shared.version import check_for_updates, versions_compatible
 from shared.ws_cmd import WSCMDH
 
 class BotWaveClient:
@@ -197,8 +197,7 @@ class BotWaveServer:
         Log.info("Checking for software updates...")
 
         try:
-            latest_proto_ver = check_for_updates()
-            latest_ver = check_for_release_updates()
+            latest_proto_ver, latest_ver = check_for_updates()
 
             if latest_proto_ver:
                 Log.update(f"A protocol update is available. Latest version: {latest_proto_ver}")

--- a/server/server.py
+++ b/server/server.py
@@ -46,7 +46,7 @@ from shared.socket import BWWebSocketServer
 from shared.sstv import make_sstv_wav
 from shared.tips import TipEngine
 from shared.tls import gen_cert, save_cert
-from shared.version import check_for_updates, versions_compatible
+from shared.version import check_for_updates, versions_compatible, check_for_release_updates
 from shared.ws_cmd import WSCMDH
 
 class BotWaveClient:
@@ -194,16 +194,23 @@ class BotWaveServer:
         Log.success("Server shutdown complete")
 
     def _check_updates(self):
-        Log.info("Checking for protocol updates...")
+        Log.info("Checking for software updates...")
 
         try:
-            latest_version = check_for_updates()
+            latest_proto_ver = check_for_updates()
+            latest_ver = check_for_release_updates()
 
-            if latest_version:
-                Log.update(f"Update available! Latest version: {latest_version}")
-                Log.update("Consider updating to the latest version by running 'bw-update' in your shell.")
+            if latest_proto_ver:
+                Log.update(f"A protocol update is available. Latest version: {latest_proto_ver}")
+                Log.update("It is recommended updating to the latest version by running 'bw-update' in your shell")
+
+            elif latest_ver:
+                Log.update(f"A newer version of BotWave is available ({latest_ver})")
+                Log.update(f"Update by running 'bw-update --to {latest_ver}' in your shell")
+
             else:
-                Log.success("You are using the latest protocol version")
+                Log.success("You are using the latest version")
+
         except Exception as e:
             Log.warning("Unable to check for updates (continuing anyway)")
 

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -39,7 +39,7 @@ class Logger(DLogger):
         'file': 'yellow',
         'handler': 'magenta',
         'version': 'bright_cyan',
-        'update': 'bright_yellow',
+        'update': 'bright_yellow bold',
         'sstv': 'bright_blue',
         'auth': 'blue',
         'tls': 'red',

--- a/shared/version.py
+++ b/shared/version.py
@@ -5,41 +5,15 @@ from typing import Optional
 from shared.env import Env
 from shared.protocol import PROTOCOL_VERSION
 
-# if mismatch of 1st or 2nd part: error
-VERSION_CHECK_URL = "https://botwave.dpip.lol/api/latestpro/" # to retrieve the latest ver
+# if mismatch of 1st or 2nd part of ver: error
+LATEST_CHECK_URL = "https://botwave.dpip.lol/api/latest/" # line 1 = proto, line 2 = release
 RELEASE_FILE = "/opt/BotWave/last_release" # written by install.sh, might not exist on custom installs
-RELEASE_CHECK_URL = "https://botwave.dpip.lol/api/latestrel/"
 
 def parse_version(version_str: str) -> tuple:
     try:
         return tuple(map(int, version_str.split('.')))
     except (ValueError, AttributeError):
         return (0, 0, 0)
-
-def check_for_updates() -> Optional[str]:
-    #Check for protocol updates from remote URL
-    try:
-        req = urllib.request.Request(
-            VERSION_CHECK_URL,
-            headers={
-                "User-Agent": Env.get("VCHECK_UA", f"BotWaveVCheck/{PROTOCOL_VERSION} (+https://github.com/dpipstudio/botwave/)")
-            }
-        )
-
-        with urllib.request.urlopen(req, timeout=10) as response:
-            remote_version = response.read().decode('utf-8').strip()
-        
-        current_tuple = parse_version(PROTOCOL_VERSION)
-        remote_tuple = parse_version(remote_version)
-        
-        if remote_tuple > current_tuple:
-            return remote_version
-        
-        return None
-    
-    except (urllib.error.URLError, urllib.error.HTTPError, Exception):
-        # don't interrupt startup for client updates, we do not care
-        return None
 
 def versions_compatible(server_version: str, client_version: str) -> bool:
     server_tuple = parse_version(server_version)
@@ -63,29 +37,37 @@ def get_release_version() -> Optional[str]:
 
     return release
 
-def check_for_release_updates() -> Optional[str]:
-    # Check for a newer release
-    current_release = get_release_version()
-
-    if not current_release:
-        # nothing to check, skip
-        return None
-
+def check_for_updates() -> tuple[Optional[str], Optional[str]]:
+    # returns (new_proto_version, new_release_version), either can be None
     try:
         req = urllib.request.Request(
-            RELEASE_CHECK_URL,
+            LATEST_CHECK_URL,
             headers={
                 "User-Agent": Env.get("VCHECK_UA", f"BotWaveVCheck/{PROTOCOL_VERSION} (+https://github.com/dpipstudio/botwave/)")
             }
         )
 
         with urllib.request.urlopen(req, timeout=10) as response:
-            remote_release = response.read().decode('utf-8').strip()
+            lines = response.read().decode('utf-8').strip().splitlines()
 
-        if remote_release and remote_release != current_release:
-            return remote_release
-        
-        return None
-    
+        remote_proto = lines[0].strip() if len(lines) > 0 else None
+        remote_release = lines[1].strip() if len(lines) > 1 else None
+
+        new_proto = None
+        current_tuple = parse_version(PROTOCOL_VERSION)
+        remote_tuple = parse_version(remote_proto) if remote_proto else (0, 0, 0)
+
+        if remote_proto and remote_tuple > current_tuple:
+            new_proto = remote_proto
+
+        new_release = None
+        current_release = get_release_version()
+
+        if current_release and remote_release and remote_release != current_release:
+            new_release = remote_release
+
+        return (new_proto, new_release)
+
     except (urllib.error.URLError, urllib.error.HTTPError, Exception):
-        return None
+        # don't interrupt startup for client updates, we do not care
+        return (None, None)

--- a/shared/version.py
+++ b/shared/version.py
@@ -7,6 +7,8 @@ from shared.protocol import PROTOCOL_VERSION
 
 # if mismatch of 1st or 2nd part: error
 VERSION_CHECK_URL = "https://botwave.dpip.lol/api/latestpro/" # to retrieve the latest ver
+RELEASE_FILE = "/opt/BotWave/last_release" # written by install.sh, might not exist on custom installs
+RELEASE_CHECK_URL = "https://botwave.dpip.lol/api/latestrel/"
 
 def parse_version(version_str: str) -> tuple:
     try:
@@ -32,7 +34,9 @@ def check_for_updates() -> Optional[str]:
         
         if remote_tuple > current_tuple:
             return remote_version
+        
         return None
+    
     except (urllib.error.URLError, urllib.error.HTTPError, Exception):
         # don't interrupt startup for client updates, we do not care
         return None
@@ -41,3 +45,47 @@ def versions_compatible(server_version: str, client_version: str) -> bool:
     server_tuple = parse_version(server_version)
     client_tuple = parse_version(client_version)
     return server_tuple[:2] == client_tuple[:2]
+
+def get_release_version() -> Optional[str]:
+    # reads the release codename install.sh writes to RELEASE_FILE, like "v1.1.10-mollia"
+    # not guaranteed to exist (custom installs, manual setups, deleted file...) and can
+    # also be "local:/some/path" for local-repo installs
+
+    try:
+        with open(RELEASE_FILE, "r") as f:
+            release = f.read().strip()
+
+    except (IOError, OSError):
+        return None
+
+    if not release or release.startswith("local:"):
+        return None
+
+    return release
+
+def check_for_release_updates() -> Optional[str]:
+    # Check for a newer release
+    current_release = get_release_version()
+
+    if not current_release:
+        # nothing to check, skip
+        return None
+
+    try:
+        req = urllib.request.Request(
+            RELEASE_CHECK_URL,
+            headers={
+                "User-Agent": Env.get("VCHECK_UA", f"BotWaveVCheck/{PROTOCOL_VERSION} (+https://github.com/dpipstudio/botwave/)")
+            }
+        )
+
+        with urllib.request.urlopen(req, timeout=10) as response:
+            remote_release = response.read().decode('utf-8').strip()
+
+        if remote_release and remote_release != current_release:
+            return remote_release
+        
+        return None
+    
+    except (urllib.error.URLError, urllib.error.HTTPError, Exception):
+        return None


### PR DESCRIPTION
Adds a second, independent update check for the actual software release (e.g. `v1.0.0-oak`), separate from the existing protocol version check.

### What changed

- **`shared/version.py`**: merged the protocol check into a single `/api/latest/` call that returns both the protocol version (line 1) and release codename (line 2). `check_for_updates()` now returns a `(new_proto_version, new_release_version)` tuple instead of just the protocol version.
- **`client/client.py`** / **`server/server.py`**: updated to unpack the new tuple. Protocol updates are still called out as the priority message; release updates print as a secondary "newer version available" notice with the `bw-update --to <version>` hint.
- **`local/local.py`**: added the same update check on startup (previously had none).
- **`shared/logger.py`**: bolded the `update` log style for better visibility.