### PR TITLE
[Feature]: Cache generated SSTV WAVs, drop `output_wav` arg, add grayscale modes

### DIFF
--- a/local/local.md
+++ b/local/local.md
@@ -59,7 +59,7 @@ Once the client is running, you can use the following commands:
 | `stop` | `botwave> stop` | Stop the current broadcast. |
 | `live` | `botwave> live [frequency] [ps] [rt] [pi]` | Start a live broadcast. |
 | `queue` | `botwave> queue ?` | Manages the queue. |
-| `sstv` | `botwave> sstv <image path> [mode] [output wav name] [freq] [loop] [ps] [rt] [pi]` | Start broadcasting an image converted to SSTV (requires `pysstv`, `numpy`, `pillow`). |
+| `sstv` | `botwave> sstv <image path> [mode] [freq] [loop] [ps] [rt] [pi]` | Start broadcasting an image converted to SSTV (requires `pysstv`, `numpy`, `pillow`). |
 | `morse` | `botwave> morse <text\|file path> [wpm] [freq] [loop] [ps] [rt] [pi]` | Start broadcasting text converted to Morse code. |
 | `lf` | `botwave> lf` | List files in the upload directory. |
 | `rm` | `botwave> rm <filename\|all>` | Remove a file from the upload directory. |

--- a/local/local.py
+++ b/local/local.py
@@ -11,6 +11,7 @@
 # Licensed under GPL-v3.0 (see LICENSE)
 
 import argparse
+import hashlib
 import os
 from pathlib import Path
 from prompt_toolkit.formatted_text import ANSI
@@ -201,29 +202,25 @@ class BotWaveCLI:
             
             elif cmd == 'sstv':
                 if len(cmd_parts) < 2:
-                    Log.error("Usage: sstv <image_path> [mode] [output_wav] [frequency] [loop] [ps] [rt] [pi]")
+                    Log.error("Usage: sstv <image_path> [mode] [frequency] [loop] [ps] [rt] [pi]")
                     Log.end()
                     return True
 
                 img_path = cmd_parts[1]
                 mode = cmd_parts[2] if len(cmd_parts) > 2 else None
-                output_wav = cmd_parts[3] if len(cmd_parts) > 3 else os.path.join(self.upload_dir, os.path.splitext(os.path.basename(img_path))[0] + ".wav")
-                frequency = float(cmd_parts[4]) if len(cmd_parts) > 4 else Env.get_float("DEFAULT_FREQ", 90)
-                loop = cmd_parts[5].lower() == 'true' if len(cmd_parts) > 5 else False
-                ps = cmd_parts[6] if len(cmd_parts) > 6 else Env.get("DEFAULT_PS", "BotWave")
-                rt = cmd_parts[7] if len(cmd_parts) > 7 else Env.get("DEFAULT_RT", output_wav)
-                pi = cmd_parts[8] if len(cmd_parts) > 8 else Env.get("DEFAULT_PI", "FFFF")
 
                 if not os.path.exists(img_path):
                     Log.error(f"Image file {img_path} not found")
                     Log.end()
                     return True
 
-                Log.sstv(f"Generating SSTV WAV from {img_path} using mode {mode or 'auto'}...")
-                success = make_sstv_wav(img_path, output_wav, mode)
-                if success:
-                    Log.sstv(f"Broadcasting {output_wav} on {frequency} MHz...")
-                    self.start_broadcast(output_wav, frequency, ps, rt, pi, loop)
+                frequency = float(cmd_parts[3]) if len(cmd_parts) > 3 else Env.get_float("DEFAULT_FREQ", 90)
+                loop = cmd_parts[4].lower() == 'true' if len(cmd_parts) > 4 else False
+                ps = cmd_parts[5] if len(cmd_parts) > 5 else Env.get("DEFAULT_PS", "BotWave")
+                rt = cmd_parts[6] if len(cmd_parts) > 6 else Env.get("DEFAULT_RT", os.path.basename(img_path))
+                pi = cmd_parts[7] if len(cmd_parts) > 7 else Env.get("DEFAULT_PI", "FFFF")
+
+                self.start_sstv(img_path, mode, frequency, loop, ps, rt, pi)
 
                 Log.end()
                 return True
@@ -793,7 +790,37 @@ class BotWaveCLI:
             self.current_file = None
             self.piwave = None
             return False
-        
+
+
+    def start_sstv(self, img_path: str, mode: str|None = None, frequency: float = 90.0, loop: bool = False, ps: str = "BotWave", rt: str = "Broadcasting", pi: str = "FFFF"):
+
+        output_wav = self._sstv_cache_path(img_path, mode)
+
+        if os.path.exists(output_wav):
+            Log.sstv(f"Using cached SSTV WAV for {img_path}...")
+            success = True
+
+        else:
+            Log.sstv(f"Generating SSTV WAV from {img_path} using mode {mode or 'auto'}...")
+            success = make_sstv_wav(img_path, output_wav, mode)
+
+        if success:
+            self.start_broadcast(output_wav, frequency, ps, rt, pi, loop)
+
+        else:
+            Log.error("Failed to generate SSTV")
+
+    def _sstv_cache_path(self, img_path, mode):
+        # cache key includes mtime so editing the image busts the cache automatically
+        abs_path = os.path.abspath(img_path)
+        mtime = os.path.getmtime(abs_path)
+        key = f"{abs_path}|{mode or 'auto'}|{mtime}"
+        digest = hashlib.sha256(key.encode()).hexdigest()[:16]
+
+        cache_dir = os.path.join(tempfile.gettempdir(), "bw_sstv")
+        os.makedirs(cache_dir, exist_ok=True)
+
+        return os.path.join(cache_dir, f"{digest}.wav")
 
     def stop_broadcast(self):
         if not self.broadcasting:
@@ -942,10 +969,11 @@ class BotWaveCLI:
         Log.print("  Use 'queue ?' for detailed help", "white")
         Log.print("")
 
-        Log.print("sstv <image_path> [mode] [output_wav] [frequency] [loop] [ps] [rt] [pi]", "bright_green")
+        Log.print("sstv <image_path> [mode] [frequency] [loop] [ps] [rt] [pi]", "bright_green")
         Log.print("  Convert an image into a SSTV WAV file, and then broadcast it", "white")
+        Log.print("  Generated WAVs are cached, so re-running with the same image/mode won't regenerate", "white")
         Log.print("  Example:", "white")
-        Log.print("    sstv /path/to/mycat.png Robot36 cat.wav 90 false PsPs Cutie FFFF", "cyan")
+        Log.print("    sstv /path/to/mycat.png Robot36 90 false PsPs Cutie FFFF", "cyan")
         Log.print("")
 
         Log.print("morse <text|file> [wpm] [frequency] [loop] [ps] [rt] [pi]", "bright_green")

--- a/server/server.md
+++ b/server/server.md
@@ -60,7 +60,7 @@ targets: Specifies the target clients. Can be 'all', a client ID, a hostname, or
 | `stop` | `botwave> stop <targets>` | Stops broadcasting on specified client(s). |
 | `live` | `botwave> live <targets> [frequency] [ps] [rt] [pi]` | Start a live broadcast to client(s). |
 | `queue` | `botwave> queue ?` | Manages the queue. |
-| `sstv` | `botwave> sstv <targets> <image path> [mode] [output wav name] [freq] [loop] [ps] [rt] [pi]` | Start broadcasting an image converted to SSTV (requires `pysstv`, `numpy`, `pillow`). |
+| `sstv` | `botwave> sstv <targets> <image path> [mode] [freq] [loop] [ps] [rt] [pi]` | Start broadcasting an image converted to SSTV (requires `pysstv`, `numpy`, `pillow`). |
 | `morse` | `botwave> morse <targets> <text\|file path> [wpm] [freq] [loop] [ps] [rt] [pi]` | Start broadcasting text converted to Morse code. |
 | `list` | `botwave> list` | Lists all connected clients. |
 | `upload` | `botwave> upload <targets> <path/of/file.wav\|path/of/folder/>` | Upload a file or a folder's files to specified client(s) (Experimental). |

--- a/server/server.py
+++ b/server/server.py
@@ -11,6 +11,7 @@
 import argparse
 import asyncio
 from datetime import datetime, timezone
+import hashlib
 import json
 import os
 from prompt_toolkit.formatted_text import ANSI
@@ -677,35 +678,25 @@ class BotWaveServer:
         # OTHER MEDIA FORM
         elif command_name == 'sstv':
             if len(cmd) < 3:
-                Log.error("Usage: sstv <targets> <image_path> [mode] [output_wav] [freq] [loop] [ps] [rt] [pi]")
+                Log.error("Usage: sstv <targets> <image_path> [mode] [freq] [loop] [ps] [rt] [pi]")
                 Log.end()
                 return
             
             targets = cmd[1]
             img_path = cmd[2]
             mode = cmd[3] if len(cmd) > 3 else None
-            output_wav = cmd[4] if len(cmd) > 4 else os.path.join(tempfile.gettempdir(), os.path.splitext(os.path.basename(img_path))[0] + ".wav")
-            frequency = float(cmd[5]) if len(cmd) > 5 else Env.get_float("DEFAULT_FREQ", 90)
-            loop = cmd[6].lower() == 'true' if len(cmd) > 6 else False
-            ps = cmd[7] if len(cmd) > 7 else Env.get("DEFAULT_PS", "BotWave")
-            rt = cmd[8] if len(cmd) > 8 else Env.get("DEFAULT_RT", output_wav)
-            pi = cmd[9] if len(cmd) > 9 else Env.get("DEFAULT_PI", "FFFF")
+            frequency = float(cmd[4]) if len(cmd) > 4 else Env.get_float("DEFAULT_FREQ", 90)
+            loop = cmd[5].lower() == 'true' if len(cmd) > 5 else False
+            ps = cmd[6] if len(cmd) > 6 else Env.get("DEFAULT_PS", "BotWave")
+            rt = cmd[7] if len(cmd) > 7 else Env.get("DEFAULT_RT", os.path.basename(img_path))
+            pi = cmd[8] if len(cmd) > 8 else Env.get("DEFAULT_PI", "FFFF")
             
             if not os.path.exists(img_path):
                 Log.error(f"Image file {img_path} not found")
                 Log.end()
                 return
-            
-            Log.sstv(f"Generating SSTV WAV from {img_path}...")
-            success = make_sstv_wav(img_path, output_wav, mode)
-            
-            if success:
-                Log.sstv(f"Uploading {output_wav} to {targets}...")
-                await self.upload_file(targets, output_wav)
-                await asyncio.sleep(2)  # Wait for upload
-                
-                Log.sstv(f"Broadcasting {os.path.basename(output_wav)}...")
-                await self.start_broadcast(targets, os.path.basename(output_wav), frequency, ps, rt, pi, loop)
+
+            await self.start_sstv(targets, img_path, mode, frequency, loop, ps, rt, pi)
             
             Log.end()
             return
@@ -1650,6 +1641,48 @@ class BotWaveServer:
         self.onstop_handlers()
         return len(results['stopped']) > 0
 
+    async def start_sstv(self, client_targets: str, img_path: str, mode: str|None = None, frequency: float = 90.0, loop: bool = False, ps: str = "BotWave", rt: str = "Broadcasting", pi: str = "FFFF"):
+
+        targets = self._parse_client_targets(client_targets)
+        
+        if not targets:
+            Log.warning("No client(s) found matching the query")
+            return False
+
+        output_wav = self._sstv_cache_path(img_path, mode)
+
+        if os.path.exists(output_wav):
+            Log.sstv(f"Using cached SSTV WAV for {img_path}...")
+            success = True
+
+        else:
+            Log.sstv(f"Generating SSTV WAV from {img_path} using mode {mode or 'auto'}...")
+            success = make_sstv_wav(img_path, output_wav, mode)
+        
+        if success:
+            Log.sstv(f"Uploading {output_wav} to {client_targets}...")
+            await self.upload_file(client_targets, output_wav)
+            await asyncio.sleep(2)  # Wait for upload
+            
+            return await self.start_broadcast(client_targets, os.path.basename(output_wav), frequency, ps, rt, pi, loop)
+
+        else:
+            Log.error("Failed to generate SSTV")
+
+        return False
+
+    def _sstv_cache_path(self, img_path, mode):
+            # cache key includes mtime so editing the image busts the cache automatically
+            abs_path = os.path.abspath(img_path)
+            mtime = os.path.getmtime(abs_path)
+            key = f"{abs_path}|{mode or 'auto'}|{mtime}"
+            digest = hashlib.sha256(key.encode()).hexdigest()[:16]
+    
+            cache_dir = os.path.join(tempfile.gettempdir(), "bw_sstv")
+            os.makedirs(cache_dir, exist_ok=True)
+    
+            return os.path.join(cache_dir, f"{digest}.wav")
+
     async def kick_client(self, client_targets: str, reason: str = "Kicked by administrator"):
         target_clients = self._parse_client_targets(client_targets)
         if not target_clients:
@@ -1939,10 +1972,10 @@ class BotWaveServer:
         Log.print("    live all", "cyan")
         Log.print("")
 
-        Log.print("sstv <targets> <image_path> [mode] [output_wav] [frequency] [loop] [ps] [rt] [pi]", "bright_green")
+        Log.print("sstv <targets> <image_path> [mode] [frequency] [loop] [ps] [rt] [pi]", "bright_green")
         Log.print("  Convert an image into a SSTV WAV file, and then broadcast it", "white")
         Log.print("  Example:", "white")
-        Log.print("    sstv all /path/to/mycat.png Robot36 cat.wav 90 false PsPs Cutie FFFF", "cyan")
+        Log.print("    sstv all /path/to/mycat.png Robot36 90 false PsPs Cutie FFFF", "cyan")
         Log.print("")
 
         Log.print("morse <targets> <text|file> [wpm] [freq] [loop] [ps] [rt] [pi]", "bright_green")

--- a/shared/prompt.py
+++ b/shared/prompt.py
@@ -128,7 +128,7 @@ COMMANDS = {
         "stop": Command(syntax="", targets=True),
         "queue": Command(syntax="queue [+|-|*|!|?]"),
         "live": Command(syntax="[freq] [ps] [rt] [pi]", targets=True),
-        "sstv": Command(syntax="<image_path> [mode] [output_wav] [frequency] [loop] [ps] [rt] [pi]", targets=True),
+        "sstv": Command(syntax="<image_path> [mode] [frequency] [loop] [ps] [rt] [pi]", targets=True),
         "morse": Command(syntax="<text|file> [wpm] [freq] [loop] [ps] [rt] [pi]", targets=True),
         "upload": Command(syntax="<file|folder>", targets=True),
         "dl": Command(syntax="<url>", targets=True),

--- a/shared/sstv.py
+++ b/shared/sstv.py
@@ -65,10 +65,14 @@ def make_sstv_wav(img_path: str, wav_path: str, mode_name: Optional[str] = None)
 
     if mode_name and mode_name.lower() in MODE_MAP:
         cls = MODE_MAP[mode_name.lower()]
+
     elif envmode and envmode.lower() in MODE_MAP:
         cls = MODE_MAP[envmode.lower()]
+
     else:
-        Log.warning(f"Unknown mode '{mode_name}', falling back to auto-detect")
+        if mode_name is not None: # guard against default (none)
+            Log.warning(f"Unknown mode '{mode_name}', falling back to auto-detect")
+
         cls = get_best_sstv_mode(*img.size)
         if cls is None:
             return False

--- a/shared/sstv.py
+++ b/shared/sstv.py
@@ -68,6 +68,7 @@ def make_sstv_wav(img_path: str, wav_path: str, mode_name: Optional[str] = None)
     elif envmode and envmode.lower() in MODE_MAP:
         cls = MODE_MAP[envmode.lower()]
     else:
+        Log.warning(f"Unknown mode '{mode_name}', falling back to auto-detect")
         cls = get_best_sstv_mode(*img.size)
         if cls is None:
             return False

--- a/shared/sstv.py
+++ b/shared/sstv.py
@@ -5,7 +5,9 @@ from shared.env import Env
 from shared.logger import Log
 
 try:
-    from pysstv.color import MODES
+    from pysstv.color import MODES as COLOR_MODES
+    from pysstv.grayscale import MODES as GRAYSCALE_MODES
+    MODES = list(COLOR_MODES) + list(GRAYSCALE_MODES)
     MODE_MAP = {cls.__name__.lower(): cls for cls in MODES}
 except ImportError:
     MODE_MAP = None


### PR DESCRIPTION
### What changed

- `sstv` no longer takes an `output_wav` positional arg (local + server). The WAV path is now derived automatically and cached under `<tempdir>/bw_sstv/`, based on `(image path, mode, image mtime)`. Re-running the same image+mode reuses the cached file instead of regenerating it (faster).
- `shared/sstv.py` now pulls in grayscale modes (`Robot8BW`, `Robot24BW`) alongside the existing color modes
- Passing an unrecognized `mode` now logs a warning and falls back to auto-detect instead of failing silently.

### Breaking change
Anyone with saved commands/scripts using the old signature:
```
sstv <image> [mode] [output_wav] [frequency] [loop] [ps] [rt] [pi]
```

needs to drop the `output_wav` slot:
```
sstv <image> [mode] [frequency] [loop] [ps] [rt] [pi]
```

Old invocations that supplied `output_wav` will now have that value parsed as `frequency` and throw `ValueError: could not convert string to float`.