### PR TITLE
[Feature]: Trying to reuse generated TLS certificates

### DIFF
--- a/server/ops/startup.py
+++ b/server/ops/startup.py
@@ -1,5 +1,6 @@
-import asyncio
+from pathlib import Path
 import ssl
+import tempfile
 
 from shared.env import Env
 from shared.http import BWHTTPFileServer
@@ -14,6 +15,7 @@ class StartupOp(GeneralOp):
     The server internal startup sequence.
     
     Creates the TLS certificates and keys (self-signed)
+    if they don't exist already (in /tmp/bw_certs/)
     and setups a SSL context with them.
 
     Then starts the websocket and http server.
@@ -24,13 +26,34 @@ class StartupOp(GeneralOp):
     async def startup(self):
         try:
             # tls certs (for https and wss)
-            cert_pem, key_pem = gen_cert()
-            cert_path, key_path = save_cert(cert_pem, key_pem)
-            
+            bw_certs = Path(tempfile.gettempdir()) / "bw_certs"
+            bw_certs.mkdir(exist_ok=True)
+            cert_path = bw_certs / "bw.crt"
+            key_path = bw_certs / "bw.key"
+
+            try:
+                # reuse existing certs if readable
+                cert_pem = cert_path.read_text()
+                key_pem = key_path.read_text()
+                Log.tls("Reusing existing TLS certificate")
+
+            except OSError:
+                # missing / unreadable -> regen
+                cert_pem, key_pem = gen_cert()
+
+                try:
+                    self.save_cert_to(cert_pem, key_pem, cert_path, key_path)
+
+                except OSError:
+                    # can't write to the fixed path either, fall back to good old temp files
+                    cert_path, key_path = save_cert(cert_pem, key_pem)
+
+                finally:
+                    Log.tls("Generated self-signed TLS certificate")
+
             ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
             ssl_context.load_cert_chain(cert_path, key_path)
 
-            Log.tls("Generated self-signed TLS certificate")
 
             self.owner.ws_server = BWWebSocketServer(
                 ssl_context=ssl_context,
@@ -46,6 +69,10 @@ class StartupOp(GeneralOp):
         except Exception as e:
             Log.error(f"Error starting server: {e}")
             raise UpperException("startup_fail")
+
+    def save_cert_to(self, cert_pem: str, key_pem: str, cert_path: Path, key_path: Path):
+        cert_path.write_text(cert_pem)
+        key_path.write_text(key_pem)
 
 def setup(reg):
     reg.register(StartupOp)


### PR DESCRIPTION
The server used to regen a TLS cert on each startup, polluting `/tmp/` with them. now checks if /tmp/bw_certs exist and has a certificate to reuse in it