### PR TITLE
[Fix]: Not hardcoding paths bin scripts to /opt/BotWave

### DIFF
--- a/bin/bw-autorun
+++ b/bin/bw-autorun
@@ -6,5 +6,8 @@
 # A DPIP Studio project. https://dpip.lol
 # Licensed under GPL-v3.0 (see LICENSE)
 
+# resolve the BotWave dir
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+BW_DIR="$(dirname "$(dirname "$SCRIPT_PATH")")"
 
-/opt/BotWave/venv/bin/python3 /opt/BotWave/autorun/autorun.py "$@"
+"$BW_DIR/venv/bin/python3" "$BW_DIR"/autorun/autorun.py "$@"

--- a/bin/bw-autorun
+++ b/bin/bw-autorun
@@ -10,4 +10,4 @@
 SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
 BW_DIR="$(dirname "$(dirname "$SCRIPT_PATH")")"
 
-"$BW_DIR/venv/bin/python3" "$BW_DIR"/autorun/autorun.py "$@"
+"$BW_DIR/venv/bin/python3" "$BW_DIR/autorun/autorun.py" "$@"

--- a/bin/bw-client
+++ b/bin/bw-client
@@ -6,5 +6,8 @@
 # A DPIP Studio project. https://dpip.lol
 # Licensed under GPL-v3.0 (see LICENSE)
 
+# resolve the BotWave dir
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+BW_DIR="$(dirname "$(dirname "$SCRIPT_PATH")")"
 
-/opt/BotWave/venv/bin/python3 /opt/BotWave/client/client.py "$@"
+"$BW_DIR/venv/bin/python3" "$BW_DIR/client/client.py" "$@"

--- a/bin/bw-local
+++ b/bin/bw-local
@@ -6,5 +6,8 @@
 # A DPIP Studio project. https://dpip.lol
 # Licensed under GPL-v3.0 (see LICENSE)
 
+# resolve the BotWave dir
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+BW_DIR="$(dirname "$(dirname "$SCRIPT_PATH")")"
 
-/opt/BotWave/venv/bin/python3 /opt/BotWave/local/local.py "$@"
+"$BW_DIR/venv/bin/python3" "$BW_DIR/local/local.py" "$@"

--- a/bin/bw-nandl
+++ b/bin/bw-nandl
@@ -64,13 +64,14 @@ list_handlers() {
     local total_handlers=0
     local silent_count=0
     local regular_count=0
+    local cmd_count=0
 
     echo "=============================================="
     printf "%-30s %-10s %s\n" "Filename" "Type" "Status"
     echo "----------------------------------------------"
 
     shopt -s nullglob
-    local handler_files=("$BOTWAVE_DIR"/*.hdl "$BOTWAVE_DIR"/*.shdl)
+    local handler_files=("$BOTWAVE_DIR"/*.hdl "$BOTWAVE_DIR"/*.shdl "$BOTWAVE_DIR"/*.cmd)
     shopt -u nullglob
 
     if [[ ${#handler_files[@]} -gt 0 ]]; then
@@ -91,6 +92,9 @@ list_handlers() {
                 elif [[ "$filename" =~ \.hdl$ ]]; then
                     type="Regular"
                     ((regular_count++))
+                elif [[ "$filename" =~ \.cmd$ ]]; then
+                    type="Command"
+                    ((cmd_count++))
                 else
                     type="Unknown"
                 fi
@@ -171,15 +175,21 @@ open_handler() {
 
     if [[ -f "$target_file" ]] && [[ -s "$target_file" ]]; then
         echo ""
-        if validate_handler_content "$target_file"; then
-            echo ""
-            echo "=============================================="
-            cat "$target_file"
-            echo "=============================================="
-        else
+        if [[ "$target_file" =~ \.cmd$ ]]; then
+            if ! validate_cmd_shebang "$target_file"; then
+                log ERROR "Custom command validation failed. Please review and edit again if needed."
+                return 1
+            fi
+
+        elif ! validate_handler_content "$target_file"; then
             log ERROR "Handler file validation failed. Please review and edit again if needed."
             return 1
         fi
+
+        echo ""
+        echo "=============================================="
+        cat "$target_file"
+        echo "=============================================="
     else
         log WARN "Handler file is empty or was not saved."
     fi
@@ -192,6 +202,11 @@ open_handler() {
 check_handler_format() {
     local filename="$1"
     local basename=$(basename "$filename")
+
+    # no prefix required for custom commands
+    if [[ "$basename" =~ \.cmd$ ]]; then
+        return 0
+    fi
 
     if [[ ! "$basename" =~ \.(hdl|shdl)$ ]]; then
         return 1
@@ -248,6 +263,23 @@ validate_handler_content() {
             return 1
         fi
     fi
+}
+
+# check #!/<server, local, or *>/<filename without .cmd>
+validate_cmd_shebang() {
+    local filepath="$1"
+    local first_line
+
+    first_line=$(head -n 1 "$filepath")
+
+    if [[ ! "$first_line" =~ ^#!/(server|local|\*)/[^/]+$ ]]; then
+        log ERROR "Invalid shebang in $(basename "$filepath")"
+        log INFO "Expected: #!/<server, local, or *>/<filename without .cmd>"
+        log INFO "Found:    $first_line"
+        return 1
+    fi
+
+    return 0
 }
 
 # Handle commands
@@ -309,7 +341,27 @@ if [[ ! -f "$TARGET_FILE" ]]; then
     touch "$TARGET_FILE"
     chmod 644 "$TARGET_FILE"
 
-    if check_handler_format "$FILENAME"; then
+if [[ "$FILENAME" =~ \.cmd$ ]]; then
+        CMD_NAME="${FILENAME%.cmd}"
+        cat > "$TARGET_FILE" << EOF
+#!/*/$CMD_NAME
+# $CMD_NAME
+#   Description of what this command does
+
+# The line above is the help text shown by the "help" command.
+# Keep it as a single unbroken # block right after the shebang.
+#
+# Shebang scope ("server", "local", or "*" for both):
+#   server -> available in bw-server
+#   local  -> available in bw-local
+#   *      -> available in both
+#
+# Use {BW_ARGVn} to access arguments (BW_ARGV1 is the first user arg).
+# Check documentation on github.com/dpipstudio/botwave/wiki/Creating-custom-commands for more details
+
+EOF
+
+    elif check_handler_format "$FILENAME"; then
         cat > "$TARGET_FILE" << EOF
 # BotWave Handler: $FILENAME
 # Each line represents a command to be executed
@@ -332,15 +384,20 @@ fi
 
 if [[ -f "$TARGET_FILE" ]] && [[ -s "$TARGET_FILE" ]]; then
     echo ""
-    if validate_handler_content "$TARGET_FILE"; then
-        echo ""
-        echo "=============================================="
-        cat "$TARGET_FILE"
-        echo "=============================================="
-    else
+    if [[ "$TARGET_FILE" =~ \.cmd$ ]]; then
+        if ! validate_cmd_shebang "$TARGET_FILE"; then
+            log ERROR "Custom command validation failed. Please review and edit again if needed."
+            exit 1
+        fi
+        
+    elif ! validate_handler_content "$TARGET_FILE"; then
         log ERROR "Handler file validation failed. Please review and edit again if needed."
         exit 1
     fi
+    echo ""
+    echo "=============================================="
+    cat "$TARGET_FILE"
+    echo "=============================================="
 else
     log WARN "Handler file is empty or was not saved."
 fi

--- a/bin/bw-nandl
+++ b/bin/bw-nandl
@@ -43,9 +43,14 @@ if [[ -z "$1" ]]; then
     exit 1
 fi
 
+# resolve the BotWave dir
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+BW_DIR="$(dirname "$(dirname "$SCRIPT_PATH")")"
+
+HANDLERS_DIR="$BW_DIR/handlers"
+
 COMMAND="$1"
 INPUT="$2"
-BOTWAVE_DIR="/opt/BotWave/handlers"
 EDITOR="${EDITOR:-nano}"
 
 # supported handlers and commands
@@ -55,8 +60,8 @@ VALID_COMMANDS=("start" "stop" "list" "upload" "dl" "handlers" "<" "help" "exit"
 list_handlers() {
     echo ""
 
-    if [[ ! -d "$BOTWAVE_DIR" ]]; then
-        log WARN "Handler directory does not exist: $BOTWAVE_DIR"
+    if [[ ! -d "$HANDLERS_DIR" ]]; then
+        log WARN "Handler directory does not exist: $HANDLERS_DIR"
         return 1
     fi
 
@@ -71,7 +76,7 @@ list_handlers() {
     echo "----------------------------------------------"
 
     shopt -s nullglob
-    local handler_files=("$BOTWAVE_DIR"/*.hdl "$BOTWAVE_DIR"/*.shdl "$BOTWAVE_DIR"/*.cmd)
+    local handler_files=("$HANDLERS_DIR"/*.hdl "$HANDLERS_DIR"/*.shdl "$HANDLERS_DIR"/*.cmd)
     shopt -u nullglob
 
     if [[ ${#handler_files[@]} -gt 0 ]]; then
@@ -119,9 +124,9 @@ list_handlers() {
     echo "=============================================="
 
     if [[ "$found_handlers" == false ]]; then
-        log INFO "No handler files found in $BOTWAVE_DIR"
+        log INFO "No handler files found in $HANDLERS_DIR"
         log INFO "Checking directory permissions..."
-        ls -la "$BOTWAVE_DIR" 2>/dev/null || log ERROR "Cannot access directory $BOTWAVE_DIR"
+        ls -la "$HANDLERS_DIR" 2>/dev/null || log ERROR "Cannot access directory $HANDLERS_DIR"
     fi
 
     return 0
@@ -134,7 +139,7 @@ show_handler() {
     if [[ "$handler" == *"/"* ]]; then
         target_file="$handler"
     else
-        target_file="$BOTWAVE_DIR/$handler"
+        target_file="$HANDLERS_DIR/$handler"
     fi
 
     if [[ ! -f "$target_file" ]]; then
@@ -161,7 +166,7 @@ open_handler() {
     if [[ "$handler" == *"/"* ]]; then
         target_file="$handler"
     else
-        target_file="$BOTWAVE_DIR/$handler"
+        target_file="$HANDLERS_DIR/$handler"
     fi
 
     if [[ ! -f "$target_file" ]]; then
@@ -311,8 +316,8 @@ if [[ "$INPUT" == *"/"* ]]; then
     TARGET_DIR=$(dirname "$TARGET_FILE")
 else
     # just a file, use default dir
-    TARGET_FILE="$BOTWAVE_DIR/$INPUT"
-    TARGET_DIR="$BOTWAVE_DIR"
+    TARGET_FILE="$HANDLERS_DIR/$INPUT"
+    TARGET_DIR="$HANDLERS_DIR"
 fi
 
 if [[ ! -d "$TARGET_DIR" ]]; then
@@ -389,7 +394,7 @@ if [[ -f "$TARGET_FILE" ]] && [[ -s "$TARGET_FILE" ]]; then
             log ERROR "Custom command validation failed. Please review and edit again if needed."
             exit 1
         fi
-        
+
     elif ! validate_handler_content "$TARGET_FILE"; then
         log ERROR "Handler file validation failed. Please review and edit again if needed."
         exit 1

--- a/bin/bw-server
+++ b/bin/bw-server
@@ -6,4 +6,8 @@
 # A DPIP Studio project. https://dpip.lol
 # Licensed under GPL-v3.0 (see LICENSE)
 
-/opt/BotWave/venv/bin/python3 /opt/BotWave/server/server.py "$@"
+# resolve the BotWave dir
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+BW_DIR="$(dirname "$(dirname "$SCRIPT_PATH")")"
+
+"$BW_DIR/venv/bin/python3" "$BW_DIR/server/server.py" "$@"


### PR DESCRIPTION
Previously, scripts located in `bin/` supposed that every ressource was in `/opt/BotWave`. However, this isn't always true, e.g., when someone installed BotWave manually. This PR fixes this by retrieving the parent-parent folder of executed script. E.g. `/home/pi/botwave/bin/bw-local` will now correctly start `/home/pi/botwave/venv/bin/python3 /home/pi/botwave/local/local.py`.