### PR TITLE
[Fix]: Project paths are now dynamically built instead of hardcoded

### DIFF
--- a/autorun/autorun.py
+++ b/autorun/autorun.py
@@ -8,6 +8,7 @@
 # Licensed under GPL-v3.0 (see LICENSE)
 
 import os
+from pathlib import Path
 import sys
 import subprocess
 import argparse
@@ -15,12 +16,16 @@ import platform
 from typing import List
 from dlogger import DLogger
 
+# using this to access to the shared dir files
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from shared.dirutils import BW_PATH
+
 # Configuration
-BOTWAVE_BASE_DIR = "/opt/BotWave"
-VENV_PYTHON = "/opt/BotWave/venv/bin/python3"
-CLIENT_SCRIPT = "/opt/BotWave/client/client.py"
-SERVER_SCRIPT = "/opt/BotWave/server/server.py"
-LOCAL_SCRIPT = "/opt/BotWave/local/local.py"
+VENV_PYTHON = str(Path(BW_PATH) / "venv" / "bin" / "python3")
+CLIENT_SCRIPT = str(Path(BW_PATH) / "client" / "client.py")
+SERVER_SCRIPT = str(Path(BW_PATH) / "server" / "server.py")
+LOCAL_SCRIPT = str(Path(BW_PATH) / "local" / "local.py")
 SYSTEMD_DIR = "/etc/systemd/system"
 
 Log = DLogger(
@@ -80,8 +85,8 @@ Group=root
 KillSignal=SIGINT
 
 #environment
-Environment=PYTHONPATH=/opt/BotWave
-Environment=PATH=/opt/BotWave/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=PYTHONPATH={BW_PATH}
+Environment=PATH={BW_PATH}/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [Install]
 WantedBy=multi-user.target
@@ -165,8 +170,8 @@ def check_system_requirements():
         errors.append("systemd is required but not found")
     if os.geteuid() != 0:
         errors.append("This script must be run as root (use sudo)")
-    if not os.path.exists(BOTWAVE_BASE_DIR):
-        errors.append(f"BotWave directory not found: {BOTWAVE_BASE_DIR}")
+    if not os.path.exists(BW_PATH):
+        errors.append(f"BotWave directory not found: {BW_PATH}")
     if not os.path.exists(VENV_PYTHON):
         errors.append(f"Python virtual environment not found: {VENV_PYTHON}")
     if errors:
@@ -189,8 +194,8 @@ def check_script_exists(script_path: str, script_type: str):
 
 def create_directories():
     directories = [
-        "/opt/BotWave/uploads",
-        "/opt/BotWave/handlers"
+        f"{BW_PATH}/uploads",
+        f"{BW_PATH}/handlers"
     ]
     for directory in directories:
         os.makedirs(directory, exist_ok=True)

--- a/client/client.py
+++ b/client/client.py
@@ -13,11 +13,11 @@ from pathlib import Path
 import sys
 
 # using this to access to the shared dir files
-BW_PATH = str(Path(__file__).resolve().parent.parent)
-sys.path.append(BW_PATH)
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from shared.alsa import Alsa
 from shared.cat import check
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 from shared.protocol import Commands, ProtocolParser

--- a/client/client.py
+++ b/client/client.py
@@ -13,7 +13,8 @@ from pathlib import Path
 import sys
 
 # using this to access to the shared dir files
-sys.path.append(str(Path(__file__).resolve().parent.parent))
+BW_PATH = str(Path(__file__).resolve().parent.parent)
+sys.path.append(BW_PATH)
 
 from shared.alsa import Alsa
 from shared.cat import check
@@ -141,7 +142,7 @@ async def main():
     set_prio("SERVER_PORT", args.port, 9938, immutable=True)
     set_prio("FHOST", args.fhost, Env.get("SERVER_HOST"), immutable=True)
     set_prio("FPORT", args.fport, 9921, immutable=True)
-    set_prio("UPLOAD_DIR", args.upload_dir, '/opt/BotWave/uploads/')
+    set_prio("UPLOAD_DIR", args.upload_dir, str(Path(BW_PATH) / "uploads"))
     set_prio("TALK", args.talk, False)
     set_prio("SKIP_CHECKS", args.skip_checks, False)
 

--- a/local/local.py
+++ b/local/local.py
@@ -17,12 +17,12 @@ import shlex
 import sys
 
 # using this to access to the shared dir files
-BW_PATH = str(Path(__file__).resolve().parent.parent)
-sys.path.append(BW_PATH)
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from shared.alsa import Alsa
 from shared.cat import check
 from shared.custom_cmds import CCMD
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.handlers import HandlerExecutor
 from shared.logger import Log

--- a/local/local.py
+++ b/local/local.py
@@ -17,7 +17,8 @@ import shlex
 import sys
 
 # using this to access to the shared dir files
-sys.path.append(str(Path(__file__).resolve().parent.parent))
+BW_PATH = str(Path(__file__).resolve().parent.parent)
+sys.path.append(BW_PATH)
 
 from shared.alsa import Alsa
 from shared.cat import check
@@ -172,12 +173,12 @@ async def main():
     if args.config:
         Env.load(args.config)
 
-    set_prio("UPLOAD_DIR", args.upload_dir, '/opt/BotWave/uploads/')
-    set_prio("HANDLERS_DIR", args.handlers_dir, '/opt/BotWave/handlers/')
+    set_prio("UPLOAD_DIR", args.upload_dir, str(Path(BW_PATH) / "uploads"))
+    set_prio("HANDLERS_DIR", args.handlers_dir, str(Path(BW_PATH) / "handlers"))
     set_prio("SKIP_CHECKS", args.skip_checks, False)
     set_prio("DAEMON", args.daemon, False, immutable=True)
     set_prio("HOST", None, "0.0.0.0", immutable=True)
-    set_prio("HISTORY_PATH", None, "/opt/BotWave/.history")
+    set_prio("HISTORY_PATH", None, str(Path(BW_PATH) / ".history"))
     set_prio("PROMPT_TEXT", None, "botwave › ")
     set_prio("TALK", args.talk, False)
     set_prio("PASSKEY", args.pk, None, immutable=True)
@@ -225,7 +226,7 @@ async def main():
 
     prompt = get_prompt(
         commands={op.name: op.syntax for op in local.registry.get_instances() if isinstance(op, CliOp)},
-        history_path=Env.get("HISTORY_PATH", "/opt/BotWave/.history")
+        history_path=Env.get("HISTORY_PATH")
         )
 
     Log.print("Type 'help' for commands", 'bright_yellow')

--- a/local/ops/upload.py
+++ b/local/ops/upload.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from shared.converter import Converter, ConvertError, SUPPORTED_EXTENSIONS
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 from shared.ops import CliOp
@@ -26,7 +27,7 @@ class UploadOp(CliOp):
         allowed_source_dirs = [
             '/tmp',
             '/home',
-            '/opt/BotWave',
+            BW_PATH,
             Env.get("UPLOAD_DIR"),
             Path.home()
         ]

--- a/server/ops/sync.py
+++ b/server/ops/sync.py
@@ -5,6 +5,7 @@ import tempfile
 import uuid
 
 from shared.converter import SUPPORTED_EXTENSIONS
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 from shared.ops import CliOp
@@ -242,7 +243,7 @@ class SyncOp(CliOp):
 
         allowed_dirs = [
             tempfile.gettempdir(),
-            "/opt/BotWave",
+            BW_PATH,
             Path.home(),
             *extra_dirs
         ]

--- a/server/ops/upload.py
+++ b/server/ops/upload.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import tempfile
 
 from shared.converter import Converter, SUPPORTED_EXTENSIONS
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 from shared.ops import CliOp
@@ -47,7 +48,7 @@ class UploadOp(CliOp):
 
         allowed_source_dirs = [
             tempfile.gettempdir(),
-            "/opt/BotWave",
+            BW_PATH,
             Path.home(),
             *extra_dirs
         ]

--- a/server/server.py
+++ b/server/server.py
@@ -20,12 +20,12 @@ import traceback
 from typing import Dict, List, Optional
 
 # using this to access to the shared dir files
-BW_PATH = str(Path(__file__).resolve().parent.parent)
-sys.path.append(BW_PATH)
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from shared.alsa import Alsa
 from shared.cat import check
 from shared.custom_cmds import CCMD
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.handlers import HandlerExecutor
 from shared.logger import Log

--- a/server/server.py
+++ b/server/server.py
@@ -20,7 +20,8 @@ import traceback
 from typing import Dict, List, Optional
 
 # using this to access to the shared dir files
-sys.path.append(str(Path(__file__).resolve().parent.parent))
+BW_PATH = str(Path(__file__).resolve().parent.parent)
+sys.path.append(BW_PATH)
 
 from shared.alsa import Alsa
 from shared.cat import check
@@ -282,13 +283,14 @@ async def main():
     set_prio("HOST", args.host, '0.0.0.0', immutable=True)
     set_prio("PORT", args.port, 9938, immutable=True)
     set_prio("FPORT", args.fport, 9921, immutable=True)
-    set_prio("HANDLERS_DIR", args.handlers_dir, '/opt/BotWave/handlers/')
+    set_prio("HANDLERS_DIR", args.handlers_dir, str(Path(BW_PATH) / "handlers"))
     set_prio("SKIP_CHECKS", args.skip_checks, False)
     set_prio("TALK", args.talk, False)
     set_prio("DAEMON", args.daemon, False, immutable=True)
     set_prio("REMOTE_CMD_PORT", args.rc, None, immutable=True)
     set_prio("PASSKEY", args.pk, None, immutable=True)
-    set_prio("HISTORY_PATH", None, "/opt/BotWave/.history")
+    set_prio("UPLOAD_DIR", None, str(Path(BW_PATH) / "uploads")) # not used by server, but some shared stuff needs it
+    set_prio("HISTORY_PATH", None, str(Path(BW_PATH) / ".history"))
     set_prio("PROMPT_TEXT", None, "botwave › ")
     set_prio("EXTRA_ALLOWED_DIRS", None, str(Path.cwd()))
 
@@ -357,7 +359,7 @@ async def main():
 
     prompt = get_prompt(
         commands={op.name: op.syntax for op in server.registry.get_instances() if isinstance(op, CliOp)},
-        history_path=Env.get("HISTORY_PATH", "/opt/BotWave/.history")
+        history_path=Env.get("HISTORY_PATH")
         )
 
     Log.print("Type 'help' for commands", 'bright_yellow')

--- a/shared/bw_custom.py
+++ b/shared/bw_custom.py
@@ -3,8 +3,8 @@
 from piwave.backends.base import Backend, BackendError
 from pathlib import Path
 
+from shared.dirutils import BW_PATH
 from shared.env import Env
-from shared.logger import Log
 
 class BWCustom(Backend):
     @property
@@ -48,7 +48,7 @@ class BWCustom(Backend):
         if path:
             return [str(Path(path).parent)]
         
-        return ["/opt/BotWave/backends/bw_custom/src", "/opt", "/usr/local/bin", "/usr/bin", "/bin", "/home"]
+        return [str(Path(BW_PATH) / "backends" / "bw_custom" / "src"), "/opt", "/usr/local/bin", "/usr/bin", "/bin", "/home"]
 
     def build_command(self, wav_file: str, loop: bool):
         if not Path(wav_file).exists():

--- a/shared/dirutils.py
+++ b/shared/dirutils.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+BW_PATH = str(Path(__file__).resolve().parent.parent)

--- a/shared/env.py
+++ b/shared/env.py
@@ -2,6 +2,7 @@ import os
 import re
 from typing import Dict
 
+from shared.dirutils import BW_PATH
 
 class EnvManager:
     """Manages environment variables with support for .env files and typed access."""
@@ -11,7 +12,7 @@ class EnvManager:
         self.load(filepath)
 
         # Always try to load /opt/BotWave/.env
-        self.load("/opt/BotWave/.env")
+        self.load(f"{BW_PATH}/.env")
 
     def load(self, filepath: str = ".env") -> None:
         """Load environment variables from a .env file into os.environ."""

--- a/shared/syscheck.py
+++ b/shared/syscheck.py
@@ -3,6 +3,7 @@ import os
 import sys
 from typing import Optional
 
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 
@@ -14,7 +15,7 @@ def check_backends_paths() -> Optional[str]:
     cache_file = os.path.join(current_dir, "..", "backend_path")
     envpath = Env.get("BACKEND_PATH")
 
-    search_paths = [str(Path(envpath).parent)] if envpath else ["/opt/BotWave/backends/bw_custom/src", "/opt", "/usr/local/bin", "/usr/bin", "/bin", "/home"]
+    search_paths = [str(Path(envpath).parent)] if envpath else [str(Path(BW_PATH) / "backends" / "bw_custom" / "src"), "/opt", "/usr/local/bin", "/usr/bin", "/bin", "/home"]
     exe_name = str(Path(envpath).name) if envpath else "bw_custom"
     
     if os.path.isfile(cache_file):

--- a/shared/version.py
+++ b/shared/version.py
@@ -2,12 +2,13 @@ import urllib.request
 import urllib.error
 from typing import Optional
 
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.protocol import PROTOCOL_VERSION
 
 # if mismatch of 1st or 2nd part of ver: error
 LATEST_CHECK_URL = "https://botwave.dpip.lol/api/latest/" # line 1 = proto, line 2 = release
-RELEASE_FILE = "/opt/BotWave/last_release" # written by install.sh, might not exist on custom installs
+RELEASE_FILE = f"{BW_PATH}/last_release" # written by install.sh, might not exist on custom installs
 
 def parse_version(version_str: str) -> tuple:
     try:


### PR DESCRIPTION
Similar to #90, this PR removes all `/opt/BotWave` hardcoding and instead dynamically builds a path based on the `shared/` folder location:
```py
BW_PATH = str(Path(__file__).resolve().parent.parent)
```

So an install at `/opt/BotWave` will have `/opt/BotWave/.history` as its history file, but `/home/pi/botwave` will have `/home/pi/botwave/.history`. Same for other stuff, like handlers and uploads dir