### PR TITLE
[Update]: updated commit message guidelines

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -46,7 +46,7 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add assets/installation.json
-          git diff --staged --quiet || git commit -m "assets/installation.json: ${{ steps.parse.outputs.version }}"
+          git diff --staged --quiet || git commit -m "[meta] installation.json: update for ${{ steps.parse.outputs.version }}"
           git push
           echo "new_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       

--- a/.github/workflows/wiki-mirror.yml
+++ b/.github/workflows/wiki-mirror.yml
@@ -35,7 +35,7 @@ jobs:
           git add wiki
 
           if ! git diff --cached --quiet; then
-            git commit -m "wiki: sync GitHub wiki into /wiki"
+            git commit -m "[wiki] wiki/*.md: sync GitHub wiki into /wiki"
             git push
 
           else

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@ Contributions of all kinds are welcome, whether it’s code, documentation, bug 
 
 Please take a moment to read this guide before contributing.
 
----
 
 ## Ways to Contribute
 
@@ -16,7 +15,6 @@ You can contribute by:
 - Submitting pull requests
 - Reviewing existing pull requests
 
----
 
 ## Reporting Bugs & Issues
 
@@ -33,7 +31,6 @@ When reporting an issue, try to include:
 **Security vulnerabilities should NOT be reported via issues.**  
 Please refer to the `SECURITY.md` file for responsible disclosure instructions.
 
----
 
 ## Feature Requests
 
@@ -45,7 +42,6 @@ When suggesting a feature:
 - Describe the proposed solution
 - Mention any alternatives you’ve considered
 
----
 
 ## Pull Requests
 
@@ -63,7 +59,6 @@ When opening a pull request:
 - Reference related issues if applicable
 - Be open to feedback and requested changes
 
----
 
 ## Code Style & Guidelines
 
@@ -71,23 +66,35 @@ When opening a pull request:
 - Avoid unnecessary dependencies
 - Comment complex or non-obvious logic
 
----
-
 ## Commit Messages
 
-Please use clear and descriptive commit messages.  
-For the moment, we don't have a specific commit template, such as [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), however, we'd like having:
-- No garbage commits (e.g, `adsfds`)
-- Clear mention of the component / feature affected (e.g, `server: added xy` or `added xy in server.py`)
+Even though we won't reject contributions that don't follow our commit formatting, we'd appreciate it if you followed this pattern when writing commits:
 
----
+```
+[<component>] <path>: <commit message>
+```
+
+The message is made up of 3 parts:
+
+- **Component**: the specific part of the project affected by the change. Examples: `client`, `server`, `docs`, `workflows`, etc. If you can't find a specific enough component, you can use a generic term such as `project`.
+- **Path**: the path within that component. To avoid long paths, you can omit the part that's already implied by the component. For example, if the component is `workflows`, you can simply write `wiki-mirror.yml` and we'll understand that the commit concerns `.github/workflows/wiki-mirror.yml`. If the commit affects multiple paths, you can use globbing, or separate them with commas. Examples: `ops/*.py`, `shared/tls.py, shared/http.py`.
+- **Commit message**: a short message describing your changes.
+
+### Examples
+
+```
+[server] ops/live.py: fix ALSA rate being wrongly sent
+[client] client.py: better exception handling
+[docs] README.md: update installation steps
+[workflows] wiki-mirror.yml: ensure the new commit recommendation
+[docs] client/client.md: updated cli documentation
+```
 
 ## Community & Conduct
 
 Be respectful and constructive in discussions.  
 Harassment, hate speech, or hostile behavior will not be tolerated.
 
----
 
 ## Questions
 


### PR DESCRIPTION

Replaces the previous loose commit message guidance (no specific template, just "no garbage commits" and mention the affected component/feature) with a defined format in [CONTRIBUTING.md](https://github.com/dpipstudio/botwave/blob/main/CONTRIBUTING.md):
```
[<component>] <path>: <commit message>
```

This gives contributors a concrete pattern to follow instead of open-ended advice, while still being a suggestion rather than a requirement.
Also adds a few examples to make the format easier to follow.

Workflows were also updated to match the new commit style