### PR TITLE
[Update]: Migrate to websockets 13.1 and bump min required python version to 3.10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # AGENTS.md
 
-Last reviewed: 10/07/2026
+Last reviewed: 31/07/2026
 
 Instructions for AI coding agents (Claude Code, Cursor, Copilot, Codex, etc.) working in this repo.
 
 ## What this project is
 
 BotWave broadcasts audio over FM radio using Raspberry Pi devices (via GPIO 4 / pin 7), either as a
-standalone device (`local`) or as a server managing multiple Pi clients (`server` + `client`). Python 3.9+, no build step, no test suite, see "Testing" below before assuming otherwise.
+standalone device (`local`) or as a server managing multiple Pi clients (`server` + `client`). Python 3.10+, no build step, no test suite, see "Testing" below before assuming otherwise.
 
 ## Repo layout
 

--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ BotWave lets you broadcast audio over FM radio using Raspberry Pi devices. It su
 > All requirements can be installed automatically via the installer, see below.
 
 ### Server
-- Python >= 3.9
+- Python >= 3.10
 
 ### Client
 - Raspberry Pi (models 2, 3, 4, or Zero. **Pi 5 and Pico are not supported**)
 - Root access
-- Python >= 3.9
+- Python >= 3.10
 - [bw_custom](https://github.com/dpipstudio/bw_custom)
 - (Wire or antenna connected to GPIO 4 / pin 7)
 

--- a/assets/installation.json
+++ b/assets/installation.json
@@ -249,7 +249,7 @@
       "shared/ws_cmd.py"
     ],
     "requirements": [
-      "websockets==11.0.3",
+      "websockets==13.1",
       "dlogger==1.0.5",
       "aiofiles==0.8.0",
       "aiohttp",

--- a/assets/installation.json
+++ b/assets/installation.json
@@ -141,6 +141,7 @@
       "commit": "889e5c5899a698ec8afb87c69b600cc699726e1d"
     }
   ],
+  "min_python_version": "3.10",
   "client": {
     "files": [
       "client/client.py",

--- a/client/client.md
+++ b/client/client.md
@@ -8,7 +8,7 @@ BotWave Client is a client application designed to connect to a BotWave Server, 
 
 - Raspberry Pi (Officially working: RPI 0, 1, 2, 3, and 4)
 - Root Access
-- Python >= 3.9
+- Python >= 3.10
 - [bw_custom](https://github.com/dpipstudio/bw_custom) installed
 - [PiWave](https://github.com/douxxtech/piwave) Python module
 

--- a/local/local.md
+++ b/local/local.md
@@ -8,7 +8,7 @@ BotWave Local Client is a standalone application designed to broadcast audio fil
 
 - Raspberry Pi (Officially working: RPI 0, 1, 2, 3, and 4)
 - Root Access
-- Python >= 3.9
+- Python >= 3.10
 - [bw_custom](https://github.com/dpipstudio/bw_custom) installed
 - [PiWave](https://github.com/douxxtech/piwave) Python module
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dev = [
     "psutil==7.2.2",
     "pyalsaaudio==0.11.0",
     "pyright",
-    "websockets==11.0.3",
+    "websockets==13.1",
     "pysstv",
     "numpy",
     "pillow"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -366,6 +366,25 @@ detect_local_repo() {
     done
 }
 
+# needs to the installation.json stuff
+validate_python_version() {
+    local install_json="$1"
+    local min_version=$(echo "$install_json" | jq -r ".min_python_version")
+    local current_version=$(python3 --version 2>&1 | awk '{print $2}')
+
+    local cur_major=$(echo "$current_version" | cut -d. -f1)
+    local cur_minor=$(echo "$current_version" | cut -d. -f2)
+    local req_major=$(echo "$min_version" | cut -d. -f1)
+    local req_minor=$(echo "$min_version" | cut -d. -f2)
+
+    if (( cur_major < req_major )) || { (( cur_major == req_major )) && (( cur_minor < req_minor )); }; then
+        log ERROR "Python $current_version found, but $min_version or newer is required"
+        exit 1
+    fi
+
+    log INFO "Python OK: $current_version (>= $min_version required)"
+}
+
 # version managment
 
 # Resolves what to install and how to fetch it. Prints two lines:
@@ -831,6 +850,7 @@ main() {
 
     # Fetch configuration and install
     local install_json=$(fetch_installation_config)
+    validate_python_version "$install_json"
     install_components "$mode" "$install_json" "$target_kind" "$target_ref"
 
     # Finalize

--- a/server/ops/client_message.py
+++ b/server/ops/client_message.py
@@ -1,5 +1,5 @@
 from typing import Any
-from websockets.legacy.client import WebSocketClientProtocol
+from websockets.asyncio.server import ServerConnection
 
 from shared.logger import Log
 from shared.ops import GeneralOp
@@ -20,7 +20,7 @@ class ClientMsgOp(GeneralOp):
         Commands.END: "end"
     }
 
-    async def success(self, client_id: str, parsed: ParsedCommand, websocket: WebSocketClientProtocol):
+    async def success(self, client_id: str, parsed: ParsedCommand, websocket: ServerConnection):
         """
         Commands.OK: shows a success message
         """
@@ -29,7 +29,7 @@ class ClientMsgOp(GeneralOp):
         Log.success(f"{self.owner.clients[client_id].get_display_name()}: {msg}")
 
 
-    async def error(self, client_id: str, parsed: ParsedCommand, websocket: WebSocketClientProtocol):
+    async def error(self, client_id: str, parsed: ParsedCommand, websocket: ServerConnection):
         """
         Commands.ERROR: shows an error message
         """
@@ -38,7 +38,7 @@ class ClientMsgOp(GeneralOp):
         Log.error(f"{self.owner.clients[client_id].get_display_name()}: {msg}")
 
 
-    async def end(self, client_id: str, parsed: ParsedCommand, websocket: WebSocketClientProtocol):
+    async def end(self, client_id: str, parsed: ParsedCommand, websocket: ServerConnection):
         """
         Commands.END: show a broadcast end message
         or error if 'message' is provided

--- a/server/ops/register.py
+++ b/server/ops/register.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Any
-from websockets.legacy.client import WebSocketClientProtocol
+from websockets.asyncio.server import ServerConnection
 
 from shared.env import Env
 from shared.logger import Log
@@ -18,7 +18,7 @@ class BotWaveClient:
     def __init__(
             self,
             client_id: str,
-            websocket: WebSocketClientProtocol,
+            websocket: ServerConnection,
             machine_info: dict[str, str],
             protocol_version: str
         ):

--- a/server/server.md
+++ b/server/server.md
@@ -6,7 +6,7 @@ BotWave Server is a program designed to manage multiple BotWave clients, allowin
 
 ## Requirements
 
-- Python >= 3.9
+- Python >= 3.10
 
 ## Installation
 

--- a/server/server.py
+++ b/server/server.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.patch_stdout import patch_stdout
 from typing import Any, TYPE_CHECKING
-from websockets.legacy.client import WebSocketClientProtocol
+from websockets.asyncio.server import ServerConnection
 
 # using this to access to the shared dir files
 sys.path.append(str(Path(__file__).resolve().parent.parent))
@@ -99,7 +99,7 @@ class BotWaveServer:
 
         return valid_targets
 
-    async def handle_message(self, client_id: str | None, message: str, websocket: WebSocketClientProtocol):
+    async def handle_message(self, client_id: str | None, message: str, websocket: ServerConnection):
         try:
             Log.debug(f"{client_id}: {message}")
 
@@ -207,7 +207,7 @@ class BotWaveServer:
             Log.end()
             Log.clear_transaction_id()
 
-    async def client_connect(self, client_id: str, websocket: WebSocketClientProtocol):
+    async def client_connect(self, client_id: str, websocket: ServerConnection):
         return
 
     async def client_disconnect(self, client_id: str):

--- a/shared/env.py
+++ b/shared/env.py
@@ -92,10 +92,10 @@ class EnvManager:
 
         value = self.get(key)
 
-        if value is not None:
+        if value is None:
             return default
 
-        return str(value).lower() in ("1", "true", "yes", "on", "absolutely!")
+        return value.lower() in ("1", "true", "yes", "on", "absolutely!")
 
     def __load_env(self, filepath: str) -> None:
         """Parse a .env file and return a dict of key-value pairs."""

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -3,7 +3,7 @@ import asyncio
 import contextvars
 import re
 from typing import Any
-from websockets.legacy.client import WebSocketClientProtocol
+from websockets.asyncio.server import ServerConnection
 
 from shared.env import Env
 
@@ -54,7 +54,7 @@ class Logger(DLogger):
         'environ': 'rgb(224,107,61)'
     }
 
-    ws_clients: set[WebSocketClientProtocol] = set()
+    ws_clients: set[ServerConnection] = set()
     ws_loop = None
 
     def __init__(self):
@@ -126,7 +126,7 @@ class Logger(DLogger):
     def clear_transaction_id(self):
         self.transaction_id.set(None)
 
-    def set_remote_cmd(self, socket: WebSocketClientProtocol):
+    def set_remote_cmd(self, socket: ServerConnection):
         self.remote_cmd_socket.set(socket)
 
     def clear_remote_cmd(self):

--- a/shared/socket.py
+++ b/shared/socket.py
@@ -1,10 +1,9 @@
 import asyncio
 import ssl
-import websockets
 from typing import Any, Awaitable, Callable
 from websockets.exceptions import ConnectionClosed
-from websockets.legacy.client import WebSocketClientProtocol
-from websockets.legacy.server import WebSocketServerProtocol
+from websockets.asyncio.client import ClientConnection, connect
+from websockets.asyncio.server import ServerConnection, serve
 
 from shared.env import Env
 from shared.logger import Log
@@ -20,9 +19,9 @@ class BWWebSocketServer:
         self.on_disconnect = on_disconnect_callback
         
         # client_id -> ws
-        self.clients: dict[str, WebSocketServerProtocol] = {}
+        self.clients: dict[str, ServerConnection] = {}
         
-        self.pending_clients: dict[WebSocketServerProtocol, dict[Any, Any]] = {}
+        self.pending_clients: dict[ServerConnection, dict[Any, Any]] = {}
         
         self.server = None
         self.running = False
@@ -37,7 +36,7 @@ class BWWebSocketServer:
     
     async def start(self):
         self.running = True
-        self.server = await websockets.serve( # pyright: ignore
+        self.server = await serve(
             self._handle_client,
             self.host,
             self.port,
@@ -53,7 +52,7 @@ class BWWebSocketServer:
             self.server.close()
             await self.server.wait_closed()
     
-    async def _handle_client(self, websocket: WebSocketServerProtocol, path: str):
+    async def _handle_client(self, websocket: ServerConnection):
         client_id = None
         
         try:
@@ -95,7 +94,7 @@ class BWWebSocketServer:
                 del self.clients[client_id]
                 await self.on_disconnect(client_id)
     
-    def register_client(self, websocket: WebSocketServerProtocol, client_id: str):
+    def register_client(self, websocket: ServerConnection, client_id: str):
         if websocket in self.pending_clients:
             self.pending_clients[websocket]['client_id'] = client_id
     
@@ -126,7 +125,7 @@ class BWWebSocketClient:
         self.ssl_context = ssl_context
         self.on_message = on_message_callback
         
-        self.ws: WebSocketClientProtocol | None = None
+        self.ws: ClientConnection | None = None
         self.connected = False
         self.running = False
         
@@ -145,7 +144,7 @@ class BWWebSocketClient:
 
         try:
             uri = f"wss://{self.host}:{self.port}"
-            self.ws = await websockets.connect( # pyright: ignore
+            self.ws = await connect(
                 uri,
                 ssl=self.ssl_context,
                 ping_interval=PING_INTERVAL,

--- a/shared/ws_cmd.py
+++ b/shared/ws_cmd.py
@@ -1,10 +1,9 @@
 import asyncio
 import threading
 import re
-import websockets
 from typing import Awaitable, Callable
 from websockets.exceptions import ConnectionClosed
-from websockets.legacy.client import WebSocketClientProtocol
+from websockets.asyncio.server import ServerConnection, serve
 
 
 from shared.env import Env
@@ -17,7 +16,7 @@ class WSCMDH: # WebSocket Command Handler
         
         self.command_executor = command_executor
         self.registry = registry
-        self.ws_clients: set[WebSocketClientProtocol] = set()
+        self.ws_clients: set[ServerConnection] = set()
         self.ws_loop: asyncio.AbstractEventLoop | None = None
         
     @property
@@ -58,11 +57,11 @@ class WSCMDH: # WebSocket Command Handler
         self.ws_loop.run_until_complete(self._serve())
     
     async def _serve(self):
-        async with websockets.serve(self._handle_client, self.host, self.port): # pyright: ignore
+        async with serve(self._handle_client, self.host, self.port):
             Log.server(f"Remote CLI server started on ws://{self.host}:{self.port}")
             await asyncio.Future()  # run forever
     
-    async def _handle_client(self, websocket: WebSocketClientProtocol):
+    async def _handle_client(self, websocket: ServerConnection):
         ip = websocket.remote_address[0] or "unknown"
 
         try:
@@ -107,11 +106,11 @@ class WSCMDH: # WebSocket Command Handler
             
             await self.registry.dispatch("handlers_onwsleave", context={"REMOTE_CLIENT_IP": ip})
 
-    async def _close_client(self, websocket: WebSocketClientProtocol):
+    async def _close_client(self, websocket: ServerConnection):
         await websocket.close()
         await websocket.wait_closed()
     
-    async def _inject_command(self, message: str, websocket: WebSocketClientProtocol, ip: str):
+    async def _inject_command(self, message: str, websocket: ServerConnection, ip: str):
         cmd = re.sub(r'\s*transaction_id=[^\s]+', '', message).strip()
         Log.print(cmd, 'bright_green', icon=ip)
         


### PR DESCRIPTION
This PR does three things:
- Bump the minimum supported python version to `3.10`. It previously was `3.9`, but this version reached end of life in 2025 and is not worth it to support anymore.
- Since the python version got bumped, also upgraded the code to `websockets==13.1` supporting the new asyncio library. 
- `scripts/install.sh` now enforces the minimum python version mentionned in `assets/installation.json["min_python_version"]`.

Unrelated, but also fixed a bug in shared/env.py where `get_bool()` was returning the wrong value.