### PR TITLE
[Feature]: added -v, --version to all three main bw programs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -36,8 +36,8 @@ body:
     id: version
     attributes:
       label: Version
-      description: '`/opt/BotWave/last_release`'
-      placeholder: v1.0.0-oak
+      description: '`bw-server --version`, `bw-local --version`'
+      placeholder: BotWave ??? v???, protocol ???
   - type: input
     id: machine
     attributes:

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ sudo bw-local
 usage: bw-local [-h] [--upload-dir UPLOAD_DIR] [--handlers-dir HANDLERS_DIR]
                 [--skip-checks | --no-skip-checks] [--daemon | --no-daemon]
                 [--rc RC] [--pk PK] [--talk | --no-talk] [--config CONFIG]
+                [-v]
 
 BotWave Local Client
 
@@ -196,6 +197,7 @@ options:
   --pk PK               Optional passkey for remote management authentication
   --talk, --no-talk     Show debug logs
   --config CONFIG       Path to a config file to load into environment
+  -v, --version         Display version information
 </pre>
 <hr>
 </details>
@@ -277,7 +279,7 @@ usage: bw-server [-h] [--host HOST] [--port PORT] [--fport FPORT] [--pk PK]
                  [--start-asap | --no-start-asap]
                  [--skip-checks | --no-skip-checks] [--rc RC]
                  [--talk | --no-talk] [--config CONFIG]
-                 [--daemon | --no-daemon]
+                 [--daemon | --no-daemon] [-v]
 
 BotWave Server
 
@@ -298,6 +300,7 @@ options:
   --config CONFIG       Path to a config file to load into environment
   --daemon, --no-daemon
                         Run in non-interactive daemon mode
+  -v, --version         Display version information
 </pre>
 <hr>
 </details>
@@ -319,7 +322,7 @@ sudo bw-client 192.168.1.10    # replace with your server's IP
 usage: bw-client [-h] [--port PORT] [--fhost FHOST] [--fport FPORT]
                  [--upload-dir UPLOAD_DIR] [--pk PK]
                  [--skip-checks | --no-skip-checks] [--talk | --no-talk]
-                 [--config CONFIG]
+                 [--config CONFIG] [-v]
                  [server_host]
 
 BotWave Client
@@ -340,6 +343,7 @@ options:
                         Skip update and requirements checks
   --talk, --no-talk     Show debug logs
   --config CONFIG       Path to a config file to load into environment
+  -v, --version         Display version information
 </pre>
 <hr>
 </details>

--- a/client/client.md
+++ b/client/client.md
@@ -29,7 +29,7 @@ We highly recommend using the official installer (Check the [main README](/READM
 
 To start the BotWave Client, use the following command:
 ```bash
-sudo bw-client [-h] [--port PORT] [--fhost FHOST] [--fport FPORT] [--upload-dir UPLOAD_DIR] [--pk PK] [--skip-checks | --no-skip-checks] [--talk | --no-talk] [--config CONFIG] [server_host]
+sudo bw-client [-h] [--port PORT] [--fhost FHOST] [--fport FPORT] [--upload-dir UPLOAD_DIR] [--pk PK] [--skip-checks | --no-skip-checks] [--talk | --no-talk] [--config CONFIG] [-v] [server_host]
 ```
 
 ### Arguments
@@ -43,6 +43,7 @@ sudo bw-client [-h] [--port PORT] [--fhost FHOST] [--fport FPORT] [--upload-dir 
 - `--skip-checks`: Skip system requirements checks.
 - `--talk`: Show debug logs.
 - `--config`: Path to a config file to load into environment.
+- `-v`, `--version`: Display version information.
 
 ### Example
 

--- a/client/client.py
+++ b/client/client.py
@@ -30,7 +30,7 @@ from shared.registry import Registry, UpperException
 from shared.socket import BWWebSocketClient
 from shared.syscheck import check_requirements
 from shared.tips import TipEngine
-from shared.version import check_for_updates
+from shared.version import check_for_updates, print_version
 
 class BotWaveClient:
     """
@@ -115,8 +115,6 @@ def check_updates():
 
 # entry point
 async def main():
-    Log.header("BotWave Client")
-
     check()
 
     parser = argparse.ArgumentParser(prog="bw-client", description='BotWave Client')
@@ -129,7 +127,14 @@ async def main():
     parser.add_argument('--skip-checks', dest='skip_checks', action=argparse.BooleanOptionalAction, default=None, help='Skip update and requirements checks')
     parser.add_argument('--talk', action=argparse.BooleanOptionalAction, default=None, help='Show debug logs')
     parser.add_argument('--config', type=str, help='Path to a config file to load into environment')
+    parser.add_argument('-v', '--version', action="store_true", default=False, help='Display version information')
     args = parser.parse_args()
+
+    if args.version:
+        print_version("client")
+        return
+
+    Log.header("BotWave Client")
 
     if args.config:
         Env.load(args.config) # will silently drop if file doesn't exist

--- a/local/local.md
+++ b/local/local.md
@@ -29,7 +29,7 @@ We highly recommend using the official installer (Check the [main README](/READM
 
 To start the BotWave Local Client, use the following command:
 ```bash
-sudo bw-local [-h] [--upload-dir UPLOAD_DIR] [--handlers-dir HANDLERS_DIR] [--skip-checks | --no-skip-checks] [--daemon | --no-daemon] [--rc RC] [--pk PK] [--talk | --no-talk] [--config CONFIG]
+sudo bw-local [-h] [--upload-dir UPLOAD_DIR] [--handlers-dir HANDLERS_DIR] [--skip-checks | --no-skip-checks] [--daemon | --no-daemon] [--rc RC] [--pk PK] [--talk | --no-talk] [--config CONFIG] [-v]
 ```
 
 ### Arguments
@@ -42,6 +42,7 @@ sudo bw-local [-h] [--upload-dir UPLOAD_DIR] [--handlers-dir HANDLERS_DIR] [--sk
 - `--pk`: Optional passkey for websocket authentication.
 - `--talk`: Show debug logs.
 - `--config`: Path to a config file to load into environment.
+- `-v`, `--version`: Display version information.
 
 ### Example
 

--- a/local/local.py
+++ b/local/local.py
@@ -35,7 +35,7 @@ from shared.queue import Queue
 from shared.registry import Registry, UpperException
 from shared.syscheck import check_requirements
 from shared.tips import TipEngine
-from shared.version import check_for_updates
+from shared.version import check_for_updates, print_version
 from shared.ws_cmd import WSCMDH
 
 class BotWaveLocal:
@@ -157,8 +157,6 @@ def check_updates():
 
 # Entry point
 async def main():
-    Log.header("BotWave Local Client")
-
     check() # from shared.cat
 
     parser = argparse.ArgumentParser(prog="bw-local", description='BotWave Local Client')
@@ -170,7 +168,14 @@ async def main():
     parser.add_argument('--pk', help='Optional passkey for remote management authentication')
     parser.add_argument('--talk', action=argparse.BooleanOptionalAction, help='Show debug logs')
     parser.add_argument('--config', type=str, help='Path to a config file to load into environment')
+    parser.add_argument('-v', '--version', action="store_true", default=False, help='Display version information')
     args = parser.parse_args()
+
+    if args.version:
+        print_version("local")
+        return
+
+    Log.header("BotWave Local Client")
 
     if args.config:
         Env.load(args.config)

--- a/server/server.md
+++ b/server/server.md
@@ -26,7 +26,7 @@ We highly recommend using the official installer (Check the [main README](/READM
 To start the BotWave Server, use the following command:
 
 ```bash
-bw-server [-h] [--host HOST] [--port PORT] [--fport FPORT] [--pk PK] [--handlers-dir HANDLERS_DIR] [--start-asap | --no-start-asap] [--skip-checks | --no-skip-checks] [--rc RC] [--talk | --no-talk] [--config CONFIG] [--daemon | --no-daemon]
+bw-server [-h] [--host HOST] [--port PORT] [--fport FPORT] [--pk PK] [--handlers-dir HANDLERS_DIR] [--start-asap | --no-start-asap] [--skip-checks | --no-skip-checks] [--rc RC] [--talk | --no-talk] [--config CONFIG] [--daemon | --no-daemon] [-v]
 ```
 
 ### Arguments
@@ -42,6 +42,7 @@ bw-server [-h] [--host HOST] [--port PORT] [--fport FPORT] [--pk PK] [--handlers
 - `--talk`: Show debug logs.
 - `--config`: Path to a config file to load into environment.
 - `--daemon`: Run in daemon mode (non-interactive).
+- `-v`, `--version`: Display version information.
 
 ### Example
 

--- a/server/server.py
+++ b/server/server.py
@@ -38,7 +38,7 @@ from shared.queue import Queue
 from shared.registry import Registry, UpperException
 from shared.socket import BWWebSocketServer
 from shared.tips import TipEngine
-from shared.version import check_for_updates
+from shared.version import check_for_updates, print_version
 from shared.ws_cmd import WSCMDH
 
 if TYPE_CHECKING:
@@ -265,8 +265,6 @@ def fail_banner():
 
 
 async def main():
-    Log.header("BotWave Server")
-
     check()
 
     parser = argparse.ArgumentParser(prog="bw-server", description='BotWave Server')
@@ -281,7 +279,14 @@ async def main():
     parser.add_argument('--talk', action=argparse.BooleanOptionalAction, default=None, help='Show debug logs')
     parser.add_argument('--config', type=str, help='Path to a config file to load into environment')
     parser.add_argument('--daemon', action=argparse.BooleanOptionalAction, help='Run in non-interactive daemon mode')
+    parser.add_argument('-v', '--version', action="store_true", default=False, help='Display version information')
     args = parser.parse_args()
+
+    if args.version:
+        print_version("server")
+        return
+
+    Log.header("BotWave Server")
 
     if args.config:
         Env.load(args.config) # will silently drop if file doesn't exist

--- a/shared/version.py
+++ b/shared/version.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from shared.dirutils import BW_PATH
 from shared.env import Env
+from shared.logger import Log
 from shared.protocol import PROTOCOL_VERSION
 
 # if mismatch of 1st or 2nd part of ver: error
@@ -73,3 +74,6 @@ def check_for_updates() -> tuple[Optional[str], Optional[str]]:
     except (urllib.error.URLError, urllib.error.HTTPError, Exception):
         # don't interrupt startup for client updates, we do not care
         return (None, None)
+
+def print_version(component: str):
+    Log.print(f"BotWave {component} {get_release_version() or 'v???'}, protocol {PROTOCOL_VERSION}")


### PR DESCRIPTION
This PR implements a new `-v, --version` flag to all three `bw-client`, `bw-local`, and `bw-server` components. It displays the following string:
```
BotWave {component} {current_release or "v???"}, protocol {protocol}
```

For example, this is the current server component:
```
bw-server --version
BotWave server v1.2.5-rhus, protocol 2.1.3
```

Also updated docs.