### PR TITLE
[Fix]: prevent RCE on update command

### DIFF
--- a/client/ops/update.py
+++ b/client/ops/update.py
@@ -1,4 +1,6 @@
 import asyncio
+import re
+import shlex
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -23,14 +25,35 @@ class UpdateOp(GeneralOp):
     commands = {Commands.UPDATE: "update"}
 
     async def update(self, parsed: ParsedCommand):
-        update_args = parsed['kwargs'].get('args', '')
+        version = parsed['kwargs'].get('version', '').strip()
+
+        command = ["bw-update"]
+
+        if version:
+            try:
+                tokens = shlex.split(version)
+
+            except ValueError:
+                tokens = version.split()
+
+            if len(tokens) != 1 or not re.match(r'^v\d+\.\d+\.\d+', tokens[0]):
+                Log.error(f"Invalid update version: {version}")
+
+                await self.owner.proto.reply(
+                    parsed,
+                    Commands.ERROR,
+                    message="Invalid update version"
+                )
+                return
+
+            command += [version]
 
         Log.update("Update requested by server")
-        Log.update(f"Running bw-update {update_args}".strip())
+        Log.update(f"Running {' '.join(command)}".strip())
 
         try:
-            proc = await asyncio.create_subprocess_shell(
-                f"bw-update {update_args}".strip(),
+            proc = await asyncio.create_subprocess_exec(
+                *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT
             )

--- a/server/ops/update.py
+++ b/server/ops/update.py
@@ -37,15 +37,10 @@ class UpdateOp(CliOp):
                 Log.warning("No client(s) found matching the query")
                 return
 
-        args = ''
-
         if version:
             version = version.lower().strip()
 
-            if re.match(r'^v\d+\.\d+\.\d+', version):
-                args = f"--to {version}"
-
-            else:
+            if not re.match(r'^v\d+\.\d+\.\d+', version):
                 Log.error(f"Invalid version: '{version}'. Use  a version like 'v1.0.0-oak'")
                 return
 
@@ -63,7 +58,7 @@ class UpdateOp(CliOp):
             try:
                 response = await client.proto.send(
                     Commands.UPDATE,
-                    args=args,
+                    version=version,
                     timeout=300.0
                 )
                 results['updated'].append(client_id)

--- a/shared/protocol.py
+++ b/shared/protocol.py
@@ -3,7 +3,7 @@ import shlex
 import time
 from typing import Any, TypedDict
 
-PROTOCOL_VERSION = "2.1.3"
+PROTOCOL_VERSION = "2.1.4"
 
 
 class Commands:


### PR DESCRIPTION
This PR addresses the same core issue as #98, however its implementation is a bit different:
- the client doesn't expect an `args` kwargs to be provided with the command, but only a `version`. It then does another regex validation on the version, and if it passes, sends it directly as an arg (no shell spawn) using `asyncio.create_subprocess_exec()`.
- the server now sends directly a `version` kwargs with the version,  no `--to`, no shell command building.
- `PROTOCOL_VERSION` has been bumped to `2.1.4` to reflect the changes.

closes #98 