### PR TITLE
[Feature]: new help commands

### DIFF
--- a/local/ops/dl.py
+++ b/local/ops/dl.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from shared.converter import Converter, ConvertError, SUPPORTED_EXTENSIONS
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 from shared.ops import CliOp
@@ -25,7 +26,27 @@ class DownloadOp(CliOp):
     """
 
     name = "dl"
-    syntax  = "<url> [destination]"
+    syntax = "<url> [destination]"
+    short_help = "Download an audio file from a URL"
+    long_help = """\
+Download an audio file from the given <url>.
+The file will automatically be converted to
+.wav if it is a supported format.
+
+Other positional arguments:
+[destination]: the name of the final .wav file
+"""
+    examples = [
+        "dl https://example.com/audio.mp3"
+        "dl https://example.com/file.wav myfile.wav"
+    ]
+    env_vars = {
+        "DOWNLOAD_UA": (
+            f"BotWaveDownloads/{PROTOCOL_VERSION} (+https://github.com/dpipstudio/botwave/)",
+            "The user-agent used when making the web request"
+            ),
+        "UPLOAD_DIR": (f"{BW_PATH}/uploads", "The upload directory to store the file into"),
+    }
 
     async def handle(
         self,

--- a/local/ops/dl.py
+++ b/local/ops/dl.py
@@ -37,7 +37,7 @@ Other positional arguments:
 [destination]: the name of the final .wav file
 """
     examples = [
-        "dl https://example.com/audio.mp3"
+        "dl https://example.com/audio.mp3",
         "dl https://example.com/file.wav myfile.wav"
     ]
     env_vars = {

--- a/local/ops/env.py
+++ b/local/ops/env.py
@@ -19,6 +19,19 @@ class GetOp(CliOp):
 
     name = "get"
     syntax = "<keys|glob>"
+    short_help = "Get one or more environment variables"
+    long_help = """\
+Get one or more environment variables.
+You can specify multiples <keys> at once, or use globbing
+to match a large amount of keys.
+Immutable variables are shown in orange.
+"""
+    examples = [
+        "get PORT"
+        "get PORT HOST REMOTE_CMD_PORT"
+        "get *PORT"
+        "get *"
+    ]
 
     async def handle(self, keys: list[str] = [], is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:
@@ -76,6 +89,12 @@ class SetOp(CliOp):
 
     name = "set"
     syntax = "<key> <value> [immutable]"
+    short_help = "Set an environment variable"
+    long_help  = """\
+Set an environment variable (<key>) to <value>.
+If [immutable] is 'true', the value cannot be changed without
+re-setting it as immutable. Editing those values is not recommended.
+"""
 
     async def handle(
         self,

--- a/local/ops/env.py
+++ b/local/ops/env.py
@@ -22,16 +22,17 @@ class GetOp(CliOp):
     short_help = "Get one or more environment variables"
     long_help = """\
 Get one or more environment variables.
-You can specify multiples <keys> at once, or use globbing
-to match a large amount of keys.
+You can specify multiple <keys> at once, or use globbing
+to match a large number of keys.
 Immutable variables are shown in orange.
 """
     examples = [
-        "get PORT"
-        "get PORT HOST REMOTE_CMD_PORT"
-        "get *PORT"
+        "get PORT",
+        "get PORT HOST REMOTE_CMD_PORT",
+        "get *PORT",
         "get *"
     ]
+    env_vars = {}
 
     async def handle(self, keys: list[str] = [], is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:
@@ -95,6 +96,11 @@ Set an environment variable (<key>) to <value>.
 If [immutable] is 'true', the value cannot be changed without
 re-setting it as immutable. Editing those values is not recommended.
 """
+    examples = [
+        "set PROMPT_TEXT 'bw $ '",
+        "set PORT 8888 true"
+    ]
+    env_vars = {}
 
     async def handle(
         self,

--- a/local/ops/exit.py
+++ b/local/ops/exit.py
@@ -11,6 +11,7 @@ class ExitOp(CliOp):
     """
 
     name = "exit"
+    syntax = ""
     short_help = "Shutdown and exit the local client"
     long_help = """\
 Cleanly shuts down and exits the local client.

--- a/local/ops/exit.py
+++ b/local/ops/exit.py
@@ -18,6 +18,7 @@ Cleanly shuts down and exits the local client.
     examples = [
         "exit"
     ]
+    env_vars = {}
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         self.owner.running = False

--- a/local/ops/exit.py
+++ b/local/ops/exit.py
@@ -11,6 +11,13 @@ class ExitOp(CliOp):
     """
 
     name = "exit"
+    short_help = "Shutdown and exit the local client"
+    long_help = """\
+Cleanly shuts down and exits the local client.
+"""
+    examples = [
+        "exit"
+    ]
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         self.owner.running = False

--- a/local/ops/handlers.py
+++ b/local/ops/handlers.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any
 
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 from shared.ops import CliOp, GeneralOp
@@ -15,6 +16,20 @@ class HandlersCliOp(CliOp):
 
     name = "handlers"
     syntax = "[filename]"
+    short_help = "List all handlers and custom commands available"
+    long_help = """\
+Lists all handlers (.hdl and .shdl) and custom commands
+(.cmd) files in the handlers directory.
+If a [filename] is provided, displays the content of the file.
+"""
+    examples = [
+        "handlers",
+        "handlers hello.cmd"
+    ]
+
+    env_vars = {
+        "HANDLERS_DIR": (f"{BW_PATH}/handlers", "The directory handlers are located into")
+    }
 
     async def handle(self, file: str = "", is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:

--- a/local/ops/handlers.py
+++ b/local/ops/handlers.py
@@ -11,7 +11,7 @@ class HandlersCliOp(CliOp):
     """
     The 'handlers' command OP. Lists current handlers if no
     argument provided, or displays the content of an handler file
-    if the file exists. Overall just a HanderExecutor wrapper.
+    if the file exists. Overall just a HandlerExecutor wrapper.
     """
 
     name = "handlers"
@@ -20,13 +20,12 @@ class HandlersCliOp(CliOp):
     long_help = """\
 Lists all handlers (.hdl and .shdl) and custom commands
 (.cmd) files in the handlers directory.
-If a [filename] is provided, displays the content of the file.
+If a [filename] is provided, displays the content of that file.
 """
     examples = [
         "handlers",
         "handlers hello.cmd"
     ]
-
     env_vars = {
         "HANDLERS_DIR": (f"{BW_PATH}/handlers", "The directory handlers are located into")
     }

--- a/local/ops/help.py
+++ b/local/ops/help.py
@@ -95,21 +95,21 @@ Custom commands (.cmd files) are included in both views.
         cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', syntax))
 
         def full_help():
-            Log.print(cmd_op.long_help, "white", end="")
+            Log.print(cmd_op.long_help, end="")
 
             if len(cmd_op.examples) != 0:
                 Log.print("")
-                Log.print("Examples:" if len(cmd_op.examples) > 1 else "Example:", "white")
+                Log.print("Examples:" if len(cmd_op.examples) > 1 else "Example:")
 
                 for example in cmd_op.examples:
-                    Log.print(f"  - {Log.COLORS.get('cyan')}{example}", "white")
+                    Log.print(f"  - {Log.COLORS.get('cyan')}{example}", "reset")
 
             if len(cmd_op.env_vars) != 0:
                 Log.print("")
-                Log.print(f"Environment variables:", "white")
+                Log.print(f"Environment variables:")
 
                 for name, (default, usage) in cmd_op.env_vars.items():
-                    Log.print(f"  - {name} ({default}): {usage}", "white")
+                    Log.print(f"  - {name} ({default}): {usage}")
 
         cmd_info.full_help = full_help
 
@@ -127,7 +127,7 @@ Custom commands (.cmd files) are included in both views.
         cmd_info.long_help = '\n'.join(help)
 
         def full_help():
-            Log.print(cmd_info.long_help, "white")
+            Log.print(cmd_info.long_help)
 
         cmd_info.full_help = full_help
 
@@ -139,7 +139,7 @@ Custom commands (.cmd files) are included in both views.
 
         self.list_commands(commands)
 
-        Log.print("\nUse 'help [command]' to see specific help about a command", "white")
+        Log.print("\nUse 'help [command]' to see specific help about a command")
 
     def list_commands(self, commands: list[CommandInfo]):
 
@@ -147,7 +147,7 @@ Custom commands (.cmd files) are included in both views.
         padding = longest_cmd + 4
 
         for cmd in commands:
-            Log.print(f"{cmd.name} {cmd.required_syntax}".ljust(padding) + cmd.short_help, "white")
+            Log.print(f"{cmd.name} {cmd.required_syntax}".ljust(padding) + cmd.short_help)
 
 
 def setup(reg: Any):

--- a/local/ops/help.py
+++ b/local/ops/help.py
@@ -1,143 +1,154 @@
-from typing import Any
+import re
+from typing import Any, Callable
 
 from shared.logger import Log
 from shared.ops import CliOp
 
+class CommandInfo:
+    name: str
+    is_custom: bool
+    required_syntax: str
+    full_syntax: str
+    short_help: str
+    long_help: str
+    full_help: Callable[..., None]
+
 class HelpOp(CliOp):
+    """
+    The 'help' command OP.
+    Lists every command and its syntax.
+    Also handles custom commands.
+    """
+
     name = "help"
+    syntax = "[commands]"
+    short_help = "Displays general or specific help"
+    long_help = """\
+Without arguments, lists every available command with a
+short description.
 
-    async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
-        """
-        The 'help' command OP.
-        Lists every command and its syntax (currently hardcoded, 
-        would be nice to have a dynamic system in the future).
+If one or more [commands] are given, shows the full help
+for each one: its syntax, a detailed description, examples
+and any related environment variables.
 
-        Also displays custom commands and their eventual help
-        if any
-        """
+Custom commands (.cmd files) are included in both views.
+"""
+    examples = [
+        "help",
+        "help start",
+        "help start live my_customcmd"
+    ]
+    env_vars = {}
 
+    async def handle(self, commands: list[str] = [], is_cmd: bool = False, cmd_parts: list[str] = []):
+        if is_cmd:
+            commands = self.parse(cmd_parts)
+
+        all_commands = [
+            self.get_cmd_info(cmd)
+            for cmd in self.registry.get_instances().values()
+            if isinstance(cmd, CliOp)
+        ]
+
+        all_commands += [
+            self.get_ccmd_info(ccmd)
+            for ccmd in self.owner.custom_commands.get_all()
+        ]
+
+        if commands:
+            for index, command in enumerate(commands, start=1):
+                if command in [cmd.name for cmd in all_commands]:
+                    cmd_info = next((cmd for cmd in all_commands if cmd.name == command))
+
+                    Log.print("›", "bright_green", end=" ")
+                    Log.print(
+                        f"{cmd_info.name if not cmd_info.is_custom else ''} {cmd_info.full_syntax}".strip(),
+                        "yellow",
+                        end="\n\n"
+                        )
+
+                    cmd_info.full_help()
+                
+                else:
+                    Log.warning(f"Command '{command}' not found")
+
+                if index != len(commands):
+                    Log.print("\n---------------------------------", "green", end="\n\n")
+
+            return
+
+        self.show_help(all_commands)
+
+    def parse(self, cmd_parts: list[str]):
+        return cmd_parts
+
+    def get_cmd_info(self, cmd_op: CliOp) -> CommandInfo:
+        cmd_info = CommandInfo()
+        cmd_info.name = cmd_op.name
+        cmd_info.is_custom = False
+        cmd_info.full_syntax = cmd_op.syntax
+        cmd_info.short_help = cmd_op.short_help
+        cmd_info.long_help = cmd_op.long_help
+
+        # only keep stuff inside '<>'
+        syntax = cmd_op.syntax
+        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', syntax))
+
+        def full_help():
+            Log.print(cmd_op.long_help, "white", end="")
+
+            if len(cmd_op.examples) != 0:
+                Log.print("")
+                Log.print("Examples:" if len(cmd_op.examples) > 1 else "Example:", "white")
+
+                for example in cmd_op.examples:
+                    Log.print(f"  - {Log.COLORS.get('cyan')}{example}", "white")
+
+            if len(cmd_op.env_vars) != 0:
+                Log.print("")
+                Log.print(f"Environment variables:", "white")
+
+                for name, (default, usage) in cmd_op.env_vars.items():
+                    Log.print(f"  - {name} ({default}): {usage}", "white")
+
+        cmd_info.full_help = full_help
+
+        return cmd_info
+
+    def get_ccmd_info(self, custom_command: dict[Any, Any]) -> CommandInfo:
+        cmd_info = CommandInfo()
+        cmd_info.name = custom_command["name"]
+        cmd_info.is_custom = True
+
+        help = custom_command["help"]
+        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', help[0])) if len(help) > 1 else ""
+        cmd_info.full_syntax = help[0] if len(help) > 1 else ""
+        cmd_info.short_help = help[1] if len(help) > 2 else f"The {cmd_info.name} custom command"
+        cmd_info.long_help = '\n'.join(help)
+
+        def full_help():
+            Log.print(cmd_info.long_help, "white")
+
+        cmd_info.full_help = full_help
+
+        return cmd_info
+
+    def show_help(self, commands: list[CommandInfo]):
         Log.header("BotWave Local Client - Help")
         Log.section("Available Commands")
 
-        Log.print("start <file> [frequency] [loop] [ps] [rt] [pi]", "bright_green")
-        Log.print("  Start broadcasting a WAV file", "white")
-        Log.print("  Example:", "white")
-        Log.print("    start broadcast.wav 100.5 true MyRadio \"My Radio Text\" FFFF", "cyan")
-        Log.print("")
+        self.list_commands(commands)
 
-        Log.print("stop", "bright_green")
-        Log.print("  Stop the current broadcast", "white")
-        Log.print("  Example:", "white")
-        Log.print("    stop", "cyan")
-        Log.print("")
+        Log.print("\nUse 'help [command]' to see specific help about a command", "white")
 
-        Log.print("live [freq] [ps] [rt] [pi]", "bright_green")
-        Log.print("  Start a live audio broadcast", "white")
-        Log.print("  Example:", "white")
-        Log.print("    live", "cyan")
-        Log.print("")
+    def list_commands(self, commands: list[CommandInfo]):
 
-        Log.print("queue [+|-|*|!|?]", "bright_green")
-        Log.print("  Manage broadcast queue", "white")
-        Log.print("  Use 'queue ?' for detailed help", "white")
-        Log.print("")
+        longest_cmd = max(len(f"{cmd.name} {cmd.required_syntax}") for cmd in commands)
+        padding = longest_cmd + 4
 
-        Log.print("sstv <image_path> [mode] [frequency] [loop] [ps] [rt] [pi]", "bright_green")
-        Log.print("  Convert an image into a SSTV WAV file, and then broadcast it", "white")
-        Log.print("  Generated WAVs are cached, so re-running with the same image/mode won't regenerate", "white")
-        Log.print("  Example:", "white")
-        Log.print("    sstv /path/to/mycat.png Robot36 90 false PsPs Cutie FFFF", "cyan")
-        Log.print("")
+        for cmd in commands:
+            Log.print(f"{cmd.name} {cmd.required_syntax}".ljust(padding) + cmd.short_help, "white")
 
-        Log.print("morse <text|file> [wpm] [frequency] [loop] [ps] [rt] [pi]", "bright_green")
-        Log.print("  Convert text to Morse code WAV and broadcast it", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    morse \"CQ CQ DE BOTWAVE\" 18 90 false BOTWAVE MORSE", "cyan")
-        Log.print("    morse message.txt", "cyan")
-        Log.print("")
-
-        Log.print("lf", "bright_green")
-        Log.print("  List files in the upload directory", "white")
-        Log.print("")
-
-        Log.print("rm <filename|glob>", "bright_green")
-        Log.print("  Remove a file", "white")
-        Log.print("  Example:", "white")
-        Log.print("    rm broadcast.wav", "cyan")
-        Log.print("    rm *.wav", "cyan")
-        Log.print("")
-
-        Log.print("upload <file|folder>", "bright_green")
-        Log.print("  Upload a file or folder to the upload directory", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    upload broadcast.wav", "cyan")
-        Log.print("    upload /home/bw/lib", "cyan")
-        Log.print("")
-
-        Log.print("dl <url> [destination]", "bright_green")
-        Log.print("  Download a WAV file from a URL", "white")
-        Log.print("  Example:", "white")
-        Log.print("    download http://example.com/file.wav myfile.wav", "cyan")
-        Log.print("")
-
-        Log.print("handlers [filename]", "bright_green")
-        Log.print("  List all handlers or commands in a specific handler file", "white")
-        Log.print("  Example:", "white")
-        Log.print("    handlers", "cyan")
-        Log.print("")
-
-        Log.print("< <command>", "bright_green")
-        Log.print("  Run a shell command on the main OS", "white")
-        Log.print("  Example:", "white")
-        Log.print("    < df -h", "cyan")
-        Log.print("")
-
-        Log.print("| <command>", "bright_green")
-        Log.print("  Run a shell command and pipe each output line as a BotWave command", "white")
-        Log.print("  Example:", "white")
-        Log.print("    | cat commands.txt", "cyan")
-        Log.print("")
-
-        Log.print("get <keys|glob>", "bright_green")
-        Log.print("  Get one or more environment variable(s)", "white")
-        Log.print("  Use '*' to list all environment variables", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    get PORT", "cyan")
-        Log.print("    get PORT HOST REMOTE_CMD_PORT", "cyan")
-        Log.print("    get *", "cyan")
-        Log.print("")
-
-        Log.print("set <key> <value> [immutable]", "bright_green")
-        Log.print("  Set an environment variable", "white")
-        Log.print("  If immutable is 'true', the value cannot be changed without re-setting it as immutable. Editing those values is not recommended.", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    set PROMPT_TEXT \"._.\"", "cyan")
-        Log.print("    set PASSKEY mykey true", "cyan")
-        Log.print("")
-
-        Log.print("status", "bright_green")
-        Log.print("  Show current broadcast and remote status", "white")
-        Log.print("")
-
-        Log.print("exit", "bright_green")
-        Log.print("  Exit the application", "white")
-        Log.print("  Example:", "white")
-        Log.print("    exit", "cyan")
-
-        Log.print("help", "bright_green")
-        Log.print("  Display this help message", "white")
-        Log.print("  Example:", "white")
-        Log.print("    help", "cyan")
-        Log.print("")
-
-        custom_commands = self.owner.custom_commands.get_all()
-
-        if custom_commands:
-            Log.section("Custom Commands")
-
-            for command in custom_commands:
-                for line in command["help"]:
-                    Log.print(line, style="yellow")
 
 def setup(reg: Any):
     reg.register(HelpOp)

--- a/local/ops/help.py
+++ b/local/ops/help.py
@@ -121,9 +121,9 @@ Custom commands (.cmd files) are included in both views.
         cmd_info.is_custom = True
 
         help = custom_command["help"]
-        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', help[0])) if len(help) > 1 else ""
-        cmd_info.full_syntax = help[0] if len(help) > 1 else ""
-        cmd_info.short_help = help[1] if len(help) > 2 else f"The {cmd_info.name} custom command"
+        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', help[0])) if len(help) > 0 else ""
+        cmd_info.full_syntax = help[0] if len(help) > 0 else ""
+        cmd_info.short_help = help[1] if len(help) > 1 else f"The {cmd_info.name} custom command"
         cmd_info.long_help = '\n'.join(help)
 
         def full_help():

--- a/local/ops/help.py
+++ b/local/ops/help.py
@@ -62,7 +62,7 @@ Custom commands (.cmd files) are included in both views.
 
                     Log.print("›", "bright_green", end=" ")
                     Log.print(
-                        f"{cmd_info.name if not cmd_info.is_custom else ''} {cmd_info.full_syntax}".strip(),
+                        f"{cmd_info.name if not cmd_info.is_custom else ''} {cmd_info.full_syntax or cmd_info.name}".strip(),
                         "yellow",
                         end="\n\n"
                         )

--- a/local/ops/help.py
+++ b/local/ops/help.py
@@ -22,7 +22,7 @@ class HelpOp(CliOp):
 
     name = "help"
     syntax = "[commands]"
-    short_help = "Displays general or specific help"
+    short_help = "Show general or command-specific help"
     long_help = """\
 Without arguments, lists every available command with a
 short description.

--- a/local/ops/lf.py
+++ b/local/ops/lf.py
@@ -13,6 +13,7 @@ class ListFilesOp(CliOp):
     """
 
     name = "lf"
+    syntax = ""
     short_help = "List files in the upload directory"
     long_help = short_help
     examples = [

--- a/local/ops/lf.py
+++ b/local/ops/lf.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any
 
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 from shared.ops import CliOp
@@ -12,6 +13,14 @@ class ListFilesOp(CliOp):
     """
 
     name = "lf"
+    short_help = "List files in the upload directory"
+    long_help = short_help
+    examples = [
+        "lf"
+    ]
+    env_vars = {
+        "UPLOAD_DIR": (f"{BW_PATH}/uploads", "The upload directory path")
+    }
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         target_dir = Path(Env.get("UPLOAD_DIR"))

--- a/local/ops/live.py
+++ b/local/ops/live.py
@@ -20,6 +20,36 @@ class LiveOp(CliOp):
 
     name = "live"
     syntax = "[frequency] [ps] [rt] [pi]"
+    short_help = "Start a live audio broadcast"
+    long_help = f"""\
+Starts a live audio broadcast on the given [frequency].
+To send audio to it, be sure to have the alsa loopback card
+"plughw:{Env.get('ALSA_CARD', 'BotWave')},0'.
+
+Other positional arguments:
+[ps]: Program Service, max. 8 chars
+[rt]: Radio Text, max 64 chars
+[pi]: Program Identifier, 4 hex chars
+"""
+    examples = [
+        "live",
+        "live 96.9 'BotWave'"
+    ]
+    env_vars = {
+        "ALSA_INTERFACE": ("hw", "The ALSA interface"), 
+        "ALSA_CARD": ("BotWave", "The ALSA card name"), 
+        "ALSA_DEVICE": ("1", "The ALSA device"), 
+        "ALSA_RATE": ("48000", "The ALSA rate to expect"), 
+        "ALSA_CHANNELS": ("2", "The ALSA channels to expect"), 
+        "ALSA_PERIODSIZE": ("2", "The ALSA period size to expect"), 
+        "BACKEND_PATH": ("bw_custom", "The path to the broadcast backend"),
+        "BACKEND_BYPASS_CACHE": ("false", "If the backend manager should discard its cached backend path"),
+        "SKIP_CHECKS": ("false", "If the backend manager should skip its own system requirements checks"),
+        "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
+        "DEFAULT_PS": ("BotWave", "The default program service"),
+        "DEFAULT_RT": ("Live", "The default radio text"),
+        "DEFAULT_PI": ("FFFF", "The default program identifier")
+    }
 
     async def handle(
         self,

--- a/local/ops/live.py
+++ b/local/ops/live.py
@@ -23,8 +23,8 @@ class LiveOp(CliOp):
     short_help = "Start a live audio broadcast"
     long_help = f"""\
 Starts a live audio broadcast on the given [frequency].
-To send audio to it, be sure to have the alsa loopback card
-"plughw:{Env.get('ALSA_CARD', 'BotWave')},0'.
+To send audio to it, make sure your output is set to the
+ALSA loopback card "plughw:{Env.get('ALSA_CARD', 'BotWave')},0".
 
 Other positional arguments:
 [ps]: Program Service, max. 8 chars

--- a/local/ops/morse.py
+++ b/local/ops/morse.py
@@ -47,7 +47,7 @@ Other positional arguments:
         "DEFAULT_MORSE_WPM": ("20", "The default morse words per minute"),
         "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
         "DEFAULT_PS": ("BotWave", "The default program service"),
-        "DEFAULT_RT": ("Live", "The default radio text"),
+        "DEFAULT_RT": ("Morse", "The default radio text"),
         "DEFAULT_PI": ("FFFF", "The default program identifier")
     }
 

--- a/local/ops/morse.py
+++ b/local/ops/morse.py
@@ -18,6 +18,38 @@ class MorseOp(CliOp):
 
     name = "morse"
     syntax = "<text|file> [wpm] [frequency] [loop] [ps] [rt] [pi]"
+    short_help = "Convert text to morse code and broadcast it"
+    long_help = """\
+Convert text to morse code and broadcast it.
+If the first argument is a <file>, read its content and
+convert it. If not, use the <text> itself.
+
+Generated .wav files are available into '/tmp/bw_morse/'.
+
+Other positional arguments:
+[wpm]: Words per minute to generate
+[frequency]: The frequency to broadcast to.
+[loop]: If the audio should be looped
+[ps]: Program Service, max. 8 chars
+[rt]: Radio Text, max 64 chars
+[pi]: Program Identifier, 4 hex chars
+"""
+    examples = [
+        "morse file.txt",
+        "morse 'Hello, world!' 20 96.9 true 'BotWave'"
+    ]
+    env_vars = {
+        "MORSE_FREQUENCY": ("700", "The audio frequency to generate the morse tone with"),
+        "MORSE_SAMPLE_RATE": ("48000", "The sample rate to generate the .wav file with"),
+        "BACKEND_PATH": ("bw_custom", "The path to the broadcast backend"),
+        "BACKEND_BYPASS_CACHE": ("false", "If the backend manager should discard its cached backend path"),
+        "SKIP_CHECKS": ("false", "If the backend manager should skip its own system requirements checks"),
+        "DEFAULT_MORSE_WPM": ("20", "The default morse words per minute"),
+        "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
+        "DEFAULT_PS": ("BotWave", "The default program service"),
+        "DEFAULT_RT": ("Live", "The default radio text"),
+        "DEFAULT_PI": ("FFFF", "The default program identifier")
+    }
 
     async def handle(
         self,

--- a/local/ops/queue.py
+++ b/local/ops/queue.py
@@ -11,13 +11,14 @@ class QueueOp(CliOp):
     syntax = "[+|-|*|!|?]"
     short_help = "Manage the broadcast queue"
     long_help = """\
-Broadcast the broadcast queue.
-Use 'queue ?' for detailed help.
+Manage the broadcast queue.
+Use 'queue ?' for detailed help on the available operators.
 """
     examples = [
-        "queue ?"
+        "queue ?",
         "queue +myfile.wav,myfile2.wav"
     ]
+    env_vars = {}
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         self.owner.queue.parse(' '.join(cmd_parts))

--- a/local/ops/queue.py
+++ b/local/ops/queue.py
@@ -9,6 +9,15 @@ class QueueOp(CliOp):
     
     name = "queue"
     syntax = "[+|-|*|!|?]"
+    short_help = "Manage the broadcast queue"
+    long_help = """\
+Broadcast the broadcast queue.
+Use 'queue ?' for detailed help.
+"""
+    examples = [
+        "queue ?"
+        "queue +myfile.wav,myfile2.wav"
+    ]
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         self.owner.queue.parse(' '.join(cmd_parts))

--- a/local/ops/rm.py
+++ b/local/ops/rm.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any
 
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 from shared.ops import CliOp
@@ -14,6 +15,19 @@ class RmOp(CliOp):
 
     name = "rm"
     syntax = "<filename|glob>"
+    short_help = "Remove a file from the upload directory"
+    long_help = """\
+Remove the given <filename> from the upload directory.
+If a <glob> is passed, remove all the matching files.
+"""
+    examples = [
+        "rm myfile.wav",
+        "rm *.wav"
+    ]
+    env_vars = {
+        "UPLOAD_DIR": (f"{BW_PATH}/uploads", "The upload directory to delete the file from"),
+
+    }
 
     async def handle(self, target: str = "", is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:

--- a/local/ops/sh_cmd.py
+++ b/local/ops/sh_cmd.py
@@ -15,6 +15,18 @@ class ShellOp(CliOp):
 
     name = "<"
     syntax = "<command>"
+    short_help = "Run a shell command on the host machine"
+    long_help = """\
+Run a shell <command> on the host machine and print
+its output.
+"""
+    examples = [
+        "< df -h"
+        "< ls {UPLOAD_DIR}"
+    ]
+    env_vars = {
+        "CMD_INTERPRETER": ("", "The command interpreter to use to execute the given command")
+    }
 
     async def handle(self, command: str = "", is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:
@@ -67,6 +79,18 @@ class PipeOp(CliOp):
 
     name = "|"
     syntax = "<command>"
+    short_help = "Run a shell command and pipe each output line as a BotWave command"
+    long_help = """\
+Run a shell <command> and pipe each output line as a BotWave command.
+"""
+    examples = [
+        "| echo 'start hello.wav'",
+        "| bash /opt/BotWave/scripts/script.sh"
+    ]
+    env_vars = {
+        "CMD_INTERPRETER": ("", "The command interpreter to use to execute the given command")
+    }
+
 
     async def handle(self, command: str = "", is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:

--- a/local/ops/sh_cmd.py
+++ b/local/ops/sh_cmd.py
@@ -21,7 +21,7 @@ Run a shell <command> on the host machine and print
 its output.
 """
     examples = [
-        "< df -h"
+        "< df -h",
         "< ls {UPLOAD_DIR}"
     ]
     env_vars = {

--- a/local/ops/sstv.py
+++ b/local/ops/sstv.py
@@ -18,6 +18,40 @@ class SSTVOp(CliOp):
 
     name = "sstv"
     syntax = "<image_path> [mode] [frequency] [loop] [ps] [rt] [pi]"
+    short_help = "Convert an image into SSTV audio and broadcast it"
+    long_help = """\
+Convert an <image> into SSTV audio and broadcast it.
+Without [mode] specified, select automatically the best mode
+available.
+
+Available modes: MartinM1, MartinM2, ScottieS1, ScottieS2,
+ScottieDX, Robot36, PasokonP3, PasokonP5, PasokonP7, PD90,
+PD120, PD160, PD180, PD240, PD290, WraaseSC2120, WraaseSC2180,
+Robot8BW, Robot24BW
+
+Generated .wav files are available into '/tmp/bw_sstv/'.
+
+Other positional arguments:
+[loop]: If the audio should be looped
+[ps]: Program Service, max. 8 chars
+[rt]: Radio Text, max 64 chars
+[pi]: Program Identifier, 4 hex chars
+"""
+    examples = [
+        "sstv image.png"
+        "sstv image.png Robot36 96.9 true 'BotWave'"
+    ]
+    env_vars = {
+        "SSTV_SAMPLE_RATE": ("48000", "The sample rate to generate the .wav file with"),
+        "BACKEND_PATH": ("bw_custom", "The path to the broadcast backend"),
+        "BACKEND_BYPASS_CACHE": ("false", "If the backend manager should discard its cached backend path"),
+        "SKIP_CHECKS": ("false", "If the backend manager should skip its own system requirements checks"),
+        "SSTV_DEFAULT_MODE": ("auto", "The default SSTV mode"),
+        "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
+        "DEFAULT_PS": ("BotWave", "The default program service"),
+        "DEFAULT_RT": ("Live", "The default radio text"),
+        "DEFAULT_PI": ("FFFF", "The default program identifier")
+    }
 
     async def handle(
         self,

--- a/local/ops/sstv.py
+++ b/local/ops/sstv.py
@@ -49,7 +49,7 @@ Other positional arguments:
         "SSTV_DEFAULT_MODE": ("auto", "The default SSTV mode"),
         "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
         "DEFAULT_PS": ("BotWave", "The default program service"),
-        "DEFAULT_RT": ("Live", "The default radio text"),
+        "DEFAULT_RT": ("<image filename>", "The default radio text"),
         "DEFAULT_PI": ("FFFF", "The default program identifier")
     }
 

--- a/local/ops/sstv.py
+++ b/local/ops/sstv.py
@@ -21,8 +21,8 @@ class SSTVOp(CliOp):
     short_help = "Convert an image into SSTV audio and broadcast it"
     long_help = """\
 Convert an <image> into SSTV audio and broadcast it.
-Without [mode] specified, select automatically the best mode
-available.
+If [mode] is not specified, automatically selects the best
+mode available.
 
 Available modes: MartinM1, MartinM2, ScottieS1, ScottieS2,
 ScottieDX, Robot36, PasokonP3, PasokonP5, PasokonP7, PD90,
@@ -38,7 +38,7 @@ Other positional arguments:
 [pi]: Program Identifier, 4 hex chars
 """
     examples = [
-        "sstv image.png"
+        "sstv image.png",
         "sstv image.png Robot36 96.9 true 'BotWave'"
     ]
     env_vars = {

--- a/local/ops/sstv.py
+++ b/local/ops/sstv.py
@@ -20,7 +20,7 @@ class SSTVOp(CliOp):
     syntax = "<image_path> [mode] [frequency] [loop] [ps] [rt] [pi]"
     short_help = "Convert an image into SSTV audio and broadcast it"
     long_help = """\
-Convert an <image> into SSTV audio and broadcast it.
+Convert an <image_path> into SSTV audio and broadcast it.
 If [mode] is not specified, automatically selects the best
 mode available.
 

--- a/local/ops/start.py
+++ b/local/ops/start.py
@@ -6,6 +6,7 @@ from piwave.backends import backend_classes
 from typing import Any
 
 from shared.bw_custom import BWCustom
+from shared.dirutils import BW_PATH
 from shared.env import Env
 from shared.logger import Log
 from shared.ops import CliOp
@@ -24,7 +25,28 @@ class StartOp(CliOp):
     """
 
     name = "start"
-    syntax = "<file> [freq] [loop] [ps] [rt] [pi]"
+    syntax = "<file> [frequency] [loop] [ps] [rt] [pi]"
+    short_help = "Start broadcasting a WAV file"
+    long_help = """\
+Start broadcasting a wav file from the upload
+directory on [frequency].
+
+Other positional arguments:
+[loop]: If the audio should be looped
+[ps]: Program Service, max. 8 chars
+[rt]: Radio Text, max 64 chars
+[pi]: Program Identifier, 4 hex chars
+"""
+    env_vars = {
+        "UPLOAD_DIR": (f"{BW_PATH}/uploads", "The upload directory to retrieve the file from"),
+        "BACKEND_PATH": ("bw_custom", "The path to the broadcast backend"),
+        "BACKEND_BYPASS_CACHE": ("false", "If the backend manager should discard its cached backend path"),
+        "SKIP_CHECKS": ("false", "If the backend manager should skip its own system requirements checks"),
+        "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
+        "DEFAULT_PS": ("BotWave", "The default program service"),
+        "DEFAULT_RT": ("Live", "The default radio text"),
+        "DEFAULT_PI": ("FFFF", "The default program identifier")
+    }
 
     async def handle(
         self,

--- a/local/ops/start.py
+++ b/local/ops/start.py
@@ -37,6 +37,10 @@ Other positional arguments:
 [rt]: Radio Text, max 64 chars
 [pi]: Program Identifier, 4 hex chars
 """
+    examples = [
+        "start myfile.wav",
+        "start myfile.wav 96.9 true 'BotWave'"
+    ]
     env_vars = {
         "UPLOAD_DIR": (f"{BW_PATH}/uploads", "The upload directory to retrieve the file from"),
         "BACKEND_PATH": ("bw_custom", "The path to the broadcast backend"),

--- a/local/ops/start.py
+++ b/local/ops/start.py
@@ -48,7 +48,7 @@ Other positional arguments:
         "SKIP_CHECKS": ("false", "If the backend manager should skip its own system requirements checks"),
         "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
         "DEFAULT_PS": ("BotWave", "The default program service"),
-        "DEFAULT_RT": ("Live", "The default radio text"),
+        "DEFAULT_RT": ("<filename>", "The default radio text"),
         "DEFAULT_PI": ("FFFF", "The default program identifier")
     }
 

--- a/local/ops/status.py
+++ b/local/ops/status.py
@@ -13,6 +13,7 @@ class StatusOp(CliOp):
     """
 
     name = "status"
+    syntax = ""
     short_help = "Show current broadcast and remote status"
     long_help = """\
 Prints the current broadcast status + information.

--- a/local/ops/status.py
+++ b/local/ops/status.py
@@ -20,6 +20,7 @@ If the remote CLI is enabled, also show information about it."""
     examples = [
         "status"
     ]
+    env_vars = {}
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         if self.owner.broadcasting and self.owner.current_file:

--- a/local/ops/status.py
+++ b/local/ops/status.py
@@ -13,6 +13,13 @@ class StatusOp(CliOp):
     """
 
     name = "status"
+    short_help = "Show current broadcast and remote status"
+    long_help = """\
+Prints the current broadcast status + information.
+If the remote CLI is enabled, also show information about it."""
+    examples = [
+        "status"
+    ]
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         if self.owner.broadcasting and self.owner.current_file:

--- a/local/ops/stop.py
+++ b/local/ops/stop.py
@@ -10,6 +10,11 @@ class StopOp(CliOp):
     """
 
     name = "stop"
+    short_help = "Stop the current broadcast"
+    long_help = short_help
+    examples = [
+        "stop"
+    ]
 
     async def handle(self, silent: bool = False, is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:

--- a/local/ops/stop.py
+++ b/local/ops/stop.py
@@ -15,6 +15,7 @@ class StopOp(CliOp):
     examples = [
         "stop"
     ]
+    env_vars = {}
 
     async def handle(self, silent: bool = False, is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:

--- a/local/ops/stop.py
+++ b/local/ops/stop.py
@@ -10,6 +10,7 @@ class StopOp(CliOp):
     """
 
     name = "stop"
+    syntax = ""
     short_help = "Stop the current broadcast"
     long_help = short_help
     examples = [

--- a/local/ops/upload.py
+++ b/local/ops/upload.py
@@ -17,6 +17,19 @@ class UploadOp(CliOp):
 
     name = "upload"
     syntax = "<file|dir>"
+    short_help = "Upload a file or folder to the upload directory"
+    long_help = """\
+Upload a <file> or <directory> content to the
+uploads directory. Converts the files to .wav if
+it is in a supported format.
+"""
+    examples = [
+        "upload myfile.mp3"
+        "upload Music/"
+    ]
+    env_vars = {
+        "UPLOAD_DIR": (f"{BW_PATH}/uploads", "The upload directory to store the file(s) into"),
+    }
 
     async def handle(self, target: str = "", is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:

--- a/local/ops/upload.py
+++ b/local/ops/upload.py
@@ -24,7 +24,7 @@ uploads directory. Converts the files to .wav if
 it is in a supported format.
 """
     examples = [
-        "upload myfile.mp3"
+        "upload myfile.mp3",
         "upload Music/"
     ]
     env_vars = {

--- a/server/ops/dl.py
+++ b/server/ops/dl.py
@@ -17,6 +17,17 @@ class DownloadOp(CliOp):
 
     name = "dl"
     syntax = "<targets> <url> [destination]"
+    short_help = "Request client(s) to download a file from a URL"
+    long_help = """\
+Request the given <targets> to download a file from <url>.
+The destination filename is deducted from the <url> if
+[destination] is not provided.
+"""
+    examples = [
+        "dl all https://example.com/audio.mp3",
+        "dl pi1,pi2 https://example.com/file.wav myfile.wav"
+    ]
+    env_vars = {}
 
     async def handle(
         self,

--- a/server/ops/env.py
+++ b/server/ops/env.py
@@ -19,6 +19,20 @@ class GetOp(CliOp):
 
     name = "get"
     syntax = "<keys|glob>"
+    short_help = "Get one or more environment variables"
+    long_help = """\
+Get one or more environment variables.
+You can specify multiple <keys> at once, or use globbing
+to match a large number of keys.
+Immutable variables are shown in orange.
+"""
+    examples = [
+        "get PORT",
+        "get PORT HOST FPORT",
+        "get *PORT",
+        "get *"
+    ]
+    env_vars = {}
 
     async def handle(self, keys: list[str] = [], is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:
@@ -76,6 +90,17 @@ class SetOp(CliOp):
 
     name = "set"
     syntax = "<key> <value> [immutable]"
+    short_help = "Set an environment variable"
+    long_help = """\
+Set an environment variable (<key>) to <value>.
+If [immutable] is 'true', the value cannot be changed without
+re-setting it as immutable. Editing those values is not recommended.
+"""
+    examples = [
+        "set PROMPT_TEXT \"._.\"",
+        "set PASSKEY mykey true"
+    ]
+    env_vars = {}
 
     async def handle(
         self,

--- a/server/ops/exit.py
+++ b/server/ops/exit.py
@@ -11,6 +11,16 @@ class ExitOp(CliOp):
     """
 
     name = "exit"
+    syntax = ""
+    short_help = "Shutdown and exit the server"
+    long_help = """\
+Kicks every connected client, stops the main and file
+transfer servers, then cleanly shuts down and exits.
+"""
+    examples = [
+        "exit"
+    ]
+    env_vars = {}
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         if not self.owner.running:

--- a/server/ops/handlers.py
+++ b/server/ops/handlers.py
@@ -9,12 +9,23 @@ from shared.protocol import PROTOCOL_VERSION
 class HandlersCliOp(CliOp):
     """
     The 'handlers' command OP. Lists current handlers if no
-    argument provided, or displays the content of an handler file
-    if the file exists. Overall just a HanderExecutor wrapper.
+    argument provided, or displays the content of a handler file
+    if the file exists. Overall just a HandlerExecutor wrapper.
     """
 
     name = "handlers"
     syntax = "[filename]"
+    short_help = "List all handlers or commands in a specific handler file"
+    long_help = """\
+Lists all handlers (.hdl and .shdl) and custom commands
+(.cmd) files in the handlers directory.
+If a [filename] is provided, displays the content of that file.
+"""
+    examples = [
+        "handlers",
+        "handlers hello.cmd"
+    ]
+    env_vars = {}
 
     async def handle(self, file: bool = False, is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:

--- a/server/ops/help.py
+++ b/server/ops/help.py
@@ -1,189 +1,172 @@
-from typing import Any
+import re
+from typing import Any, Callable
 
 from shared.logger import Log
 from shared.ops import CliOp
 
+class CommandInfo:
+    name: str
+    is_custom: bool
+    required_syntax: str
+    full_syntax: str
+    short_help: str
+    long_help: str
+    full_help: Callable[..., None]
+
 class HelpOp(CliOp):
     """
     The 'help' command OP.
-    Lists every command and its syntax (currently hardcoded, 
-    would be nice to have a dynamic system in the future).
-    
-    Also displays custom commands and their eventual help
-    if any
+    Lists every command and its syntax.
+    Also handles custom commands.
     """
 
     name = "help"
+    syntax = "[commands]"
+    short_help = "Show general or command-specific help"
+    long_help = """\
+Without arguments, lists every available command with a
+short description.
 
-    async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
+If one or more [commands] are given, shows the full help
+for each one: its syntax, a detailed description, examples
+and any related environment variables.
+
+Custom commands (.cmd files) are included in both views.
+"""
+    examples = [
+        "help",
+        "help start",
+        "help start live my_customcmd"
+    ]
+    env_vars = {}
+
+    async def handle(self, commands: list[str] = [], is_cmd: bool = False, cmd_parts: list[str] = []):
+        if is_cmd:
+            commands = self.parse(cmd_parts)
+
+        all_commands = [
+            self.get_cmd_info(cmd)
+            for cmd in self.registry.get_instances().values()
+            if isinstance(cmd, CliOp)
+        ]
+
+        all_commands += [
+            self.get_ccmd_info(ccmd)
+            for ccmd in self.owner.custom_commands.get_all()
+        ]
+
+        if commands:
+            for index, command in enumerate(commands, start=1):
+                if command in [cmd.name for cmd in all_commands]:
+                    cmd_info = next((cmd for cmd in all_commands if cmd.name == command))
+
+                    Log.print("›", "bright_green", end=" ")
+                    Log.print(
+                        f"{cmd_info.name if not cmd_info.is_custom else ''} {cmd_info.full_syntax}".strip(),
+                        "yellow",
+                        end="\n\n"
+                        )
+
+                    cmd_info.full_help()
+                
+                else:
+                    Log.warning(f"Command '{command}' not found")
+
+                if index != len(commands):
+                    Log.print("\n---------------------------------", "green", end="\n\n")
+
+            return
+
+        self.show_help(all_commands)
+
+    def parse(self, cmd_parts: list[str]):
+        return cmd_parts
+
+    def get_cmd_info(self, cmd_op: CliOp) -> CommandInfo:
+        cmd_info = CommandInfo()
+        cmd_info.name = cmd_op.name
+        cmd_info.is_custom = False
+        cmd_info.full_syntax = cmd_op.syntax
+        cmd_info.short_help = cmd_op.short_help
+        cmd_info.long_help = cmd_op.long_help
+
+        # only keep stuff inside '<>'
+        syntax = cmd_op.syntax
+        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', syntax))
+
+        def full_help():
+            Log.print(cmd_op.long_help, end="")
+
+            if len(cmd_op.examples) != 0:
+                Log.print("")
+                Log.print("Examples:" if len(cmd_op.examples) > 1 else "Example:")
+
+                for example in cmd_op.examples:
+                    Log.print(f"  - {Log.COLORS.get('cyan')}{example}", "reset")
+
+            if len(cmd_op.env_vars) != 0:
+                Log.print("")
+                Log.print(f"Environment variables:")
+
+                for name, (default, usage) in cmd_op.env_vars.items():
+                    Log.print(f"  - {name} ({default}): {usage}")
+
+            if "target" in cmd_info.full_syntax:
+                self.print_targets()
+
+        cmd_info.full_help = full_help
+
+        return cmd_info
+
+    def get_ccmd_info(self, custom_command: dict[Any, Any]) -> CommandInfo:
+        cmd_info = CommandInfo()
+        cmd_info.name = custom_command["name"]
+        cmd_info.is_custom = True
+
+        help = custom_command["help"]
+        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', help[0])) if len(help) > 1 else ""
+        cmd_info.full_syntax = help[0] if len(help) > 1 else ""
+        cmd_info.short_help = help[1] if len(help) > 2 else f"The {cmd_info.name} custom command"
+        cmd_info.long_help = '\n'.join(help)
+
+        def full_help():
+            Log.print(cmd_info.long_help)
+
+        cmd_info.full_help = full_help
+
+        return cmd_info
+
+    def show_help(self, commands: list[CommandInfo]):
         Log.header("BotWave Server - Help")
         Log.section("Available Commands")
 
-        Log.print("list", "bright_green")
-        Log.print("  List all connected clients", "white")
-        Log.print("  Example:", "white")
-        Log.print("    list", "cyan")
+        self.list_commands(commands)
+        self.print_targets()
+
+        Log.print("\nUse 'help [command]' to see specific help about a command")
+
+    def print_targets(self):
         Log.print("")
+        
+        Log.print("Targets:")
+        Log.print("  'all'                 All connected clients")
+        Log.print("  client_id             Specific client by ID")
+        Log.print("  hostname              Client by hostname")
+        Log.print("  Comma-separated list  Multiple clients")
+        Log.print("  Examples:")
+        Log.print(f"    - {Log.COLORS.get('cyan')}pi1,pi2", "reset")
+        Log.print(f"    - {Log.COLORS.get('cyan')}all", "reset")
+        Log.print(f"    - {Log.COLORS.get('cyan')}kitchen-pi", "reset")
 
-        Log.print("start <targets> <file> [freq] [loop] [ps] [rt] [pi]", "bright_green")
-        Log.print("  Start broadcasting on client(s)", "white")
-        Log.print("  Example:", "white")
-        Log.print("    start all broadcast.wav 100.5 MyRadio", "cyan")
-        Log.print("")
+    def list_commands(self, commands: list[CommandInfo]):
 
-        Log.print("stop <targets>", "bright_green")
-        Log.print("  Stop broadcasting on client(s)", "white")
-        Log.print("  Example:", "white")
-        Log.print("    stop all", "cyan")
-        Log.print("")
+        longest_cmd = max(len(f"{cmd.name} {cmd.required_syntax}") for cmd in commands)
+        padding = longest_cmd + 4
 
-        Log.print("queue [+|-|*|!|?]", "bright_green")
-        Log.print("  Manage broadcast queue", "white")
-        Log.print("  Use 'queue ?' for detailed help", "white")
-        Log.print("")
+        for cmd in commands:
+            Log.print(f"{cmd.name} {cmd.required_syntax}".ljust(padding) + cmd.short_help)
 
-        Log.print("live <targets> [freq] [ps] [rt] [pi]", "bright_green")
-        Log.print("  Start a live audio broadcast to client(s)", "white")
-        Log.print("  Example:", "white")
-        Log.print("    live all", "cyan")
-        Log.print("")
 
-        Log.print("sstv <targets> <image_path> [mode] [frequency] [loop] [ps] [rt] [pi]", "bright_green")
-        Log.print("  Convert an image into a SSTV WAV file, and then broadcast it", "white")
-        Log.print("  Example:", "white")
-        Log.print("    sstv all /path/to/mycat.png Robot36 90 false PsPs Cutie FFFF", "cyan")
-        Log.print("")
-
-        Log.print("morse <targets> <text|file> [wpm] [freq] [loop] [ps] [rt] [pi]", "bright_green")
-        Log.print("  Convert text to Morse code WAV and broadcast it", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    morse all \"CQ CQ DE BOTWAVE\" 18 90 false BOTWAVE MORSE", "cyan")
-        Log.print("    morse pi1 message.txt", "cyan")
-        Log.print("")
-
-        Log.print("upload <targets> <file|folder>", "bright_green")
-        Log.print("  Upload a WAV file or a folder's files to client(s)", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    upload all broadcast.wav", "cyan")
-        Log.print("    upload pi1,pi2 /home/bw/lib", "cyan")
-        Log.print("")
-
-        Log.print("sync <targets|folder> <source_target|folder>", "bright_green")
-        Log.print("  Synchronize files across clients or to/from local folders", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    sync all pi1", "cyan")
-        Log.print("    sync pi2,pi3 music", "cyan")
-        Log.print("    sync backup/ pi1", "cyan")
-        Log.print("")
-
-        Log.print("dl <targets> <url> [destination]", "bright_green")
-        Log.print("  Request client(s) to download a file from a URL", "white")
-        Log.print("  Example:", "white")
-        Log.print("    dl all http://example.com/file.wav", "cyan")
-        Log.print("")
-
-        Log.print("lf <targets>", "bright_green")
-        Log.print("  List broadcastable files on client(s)", "white")
-        Log.print("  Example:", "white")
-        Log.print("    lf all", "cyan")
-        Log.print("")
-
-        Log.print("rm <targets> <filename|glob>", "bright_green")
-        Log.print("  Remove a file from client(s)", "white")
-        Log.print("  Example:", "white")
-        Log.print("    rm all broadcast.wav", "cyan")
-        Log.print("    rm all *", "cyan")
-        Log.print("")
-
-        Log.print("kick <targets> [reason]", "bright_green")
-        Log.print("  Kick client(s) from the server", "white")
-        Log.print("  Example:", "white")
-        Log.print("    kick pi1 Maintenance", "cyan")
-        Log.print("")
-
-        Log.print("update <targets> [version]", "bright_green")
-        Log.print("  Request client(s) to update and restart", "white")
-        Log.print("  Omit version to update to the latest release", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    update all", "cyan")
-        Log.print("    update all v1.0.0-oak", "cyan")
-        Log.print("")
-
-        Log.print("handlers [filename]", "bright_green")
-        Log.print("  List all handlers or commands in a specific handler file", "white")
-        Log.print("  Example:", "white")
-        Log.print("    handlers", "cyan")
-        Log.print("")
-
-        Log.print("< <command>", "bright_green")
-        Log.print("  Run a shell command on the main OS", "white")
-        Log.print("  Example:", "white")
-        Log.print("    < df -h", "cyan")
-        Log.print("")
-
-        Log.print("| <command>", "bright_green")
-        Log.print("  Run a shell command and pipe each output line as a BotWave command", "white")
-        Log.print("  Example:", "white")
-        Log.print("    | cat commands.txt", "cyan")
-        Log.print("")
-
-        Log.print("get <keys|glob>", "bright_green")
-        Log.print("  Get one or more environment variable(s)", "white")
-        Log.print("  Use '*' to list all environment variables", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    get PORT", "cyan")
-        Log.print("    get PORT HOST FPORT", "cyan")
-        Log.print("    get *", "cyan")
-        Log.print("")
-
-        Log.print("set <key> <value> [immutable]", "bright_green")
-        Log.print("  Set an environment variable", "white")
-        Log.print("  If immutable is 'true', the value cannot be changed without re-setting it as immutable. Editing those values is not recommended.", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    set PROMPT_TEXT \"._.\"", "cyan")
-        Log.print("    set PASSKEY mykey true", "cyan")
-        Log.print("")
-
-        Log.print("status [targets]", "bright_green")
-        Log.print("  Show server status, and optionally the broadcast status of client(s)", "white")
-        Log.print("  Examples:", "white")
-        Log.print("    status", "cyan")
-        Log.print("    status all", "cyan")
-        Log.print("")
-
-        Log.print("exit", "bright_green")
-        Log.print("  Exit the application", "white")
-        Log.print("  Example:", "white")
-        Log.print("    exit", "cyan")
-        Log.print("")
-
-        Log.print("help", "bright_green")
-        Log.print("  Display this help message", "white")
-        Log.print("  Example:", "white")
-        Log.print("    help", "cyan")
-        Log.print("")
-
-        custom_commands = self.owner.custom_commands.get_all()
-
-        if custom_commands:
-            Log.section("Custom Commands")
-
-            for command in custom_commands:
-                for line in command["help"]:
-                    Log.print(line, style="yellow")
-
-                Log.print("")
-
-        Log.section("Targets")
-
-        Log.print("'all' - All connected clients", "white")
-        Log.print("client_id - Specific client by ID", "white")
-        Log.print("hostname - Client by hostname", "white")
-        Log.print("Comma-separated list - Multiple clients", "white")
-        Log.print("Example:", "white")
-        Log.print("  pi1,pi2", "cyan")
-        Log.print("  all", "cyan")
-        Log.print("  kitchen-pi", "cyan")
 
 def setup(reg: Any):
     reg.register(HelpOp)

--- a/server/ops/help.py
+++ b/server/ops/help.py
@@ -62,7 +62,7 @@ Custom commands (.cmd files) are included in both views.
 
                     Log.print("›", "bright_green", end=" ")
                     Log.print(
-                        f"{cmd_info.name if not cmd_info.is_custom else ''} {cmd_info.full_syntax}".strip(),
+                        f"{cmd_info.name if not cmd_info.is_custom else ''} {cmd_info.full_syntax or cmd_info.name}".strip(),
                         "yellow",
                         end="\n\n"
                         )

--- a/server/ops/help.py
+++ b/server/ops/help.py
@@ -124,9 +124,9 @@ Custom commands (.cmd files) are included in both views.
         cmd_info.is_custom = True
 
         help = custom_command["help"]
-        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', help[0])) if len(help) > 1 else ""
-        cmd_info.full_syntax = help[0] if len(help) > 1 else ""
-        cmd_info.short_help = help[1] if len(help) > 2 else f"The {cmd_info.name} custom command"
+        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', help[0])) if len(help) > 0 else ""
+        cmd_info.full_syntax = help[0] if len(help) > 0 else ""
+        cmd_info.short_help = help[1] if len(help) > 1 else f"The {cmd_info.name} custom command"
         cmd_info.long_help = '\n'.join(help)
 
         def full_help():

--- a/server/ops/kick.py
+++ b/server/ops/kick.py
@@ -14,6 +14,15 @@ class KickOp(CliOp):
 
     name = "kick"
     syntax = "<targets> [reason]"
+    short_help = "Kick client(s) from the server"
+    long_help = """\
+Kick the given <targets> from the server.
+A kicked client can still reconnect afterwards.
+"""
+    examples = [
+        "kick pi1 Maintenance"
+    ]
+    env_vars = {}
 
     async def handle(
         self,

--- a/server/ops/lf.py
+++ b/server/ops/lf.py
@@ -13,6 +13,15 @@ class ListFilesOp(CliOp):
 
     name = "lf"
     syntax = "<targets>"
+    short_help = "List broadcastable files on client(s)"
+    long_help = """\
+List the files present in the upload folder of the given
+<targets>.
+"""
+    examples = [
+        "lf all"
+    ]
+    env_vars = {}
 
     async def handle(
         self,

--- a/server/ops/list.py
+++ b/server/ops/list.py
@@ -10,6 +10,17 @@ class ListOp(CliOp):
     """
 
     name = "list"
+    syntax = ""
+    short_help = "List all connected clients"
+    long_help = """\
+Lists every currently connected client, along with its
+hostname, machine, system, protocol version and connection
+times.
+"""
+    examples = [
+        "list"
+    ]
+    env_vars = {}
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         if not self.owner.clients:

--- a/server/ops/live.py
+++ b/server/ops/live.py
@@ -17,6 +17,33 @@ class LiveOp(CliOp):
 
     name = "live"
     syntax = "<targets> [frequency] [ps] [rt] [pi]"
+    short_help = "Start a live audio broadcast to client(s)"
+    long_help = """\
+Start a live audio broadcast on the given [frequency] and
+stream it to <targets>.
+To send audio to it, make sure your output is set to the
+ALSA loopback card.
+
+Other positional arguments:
+[ps]: Program Service, max. 8 chars
+[rt]: Radio Text, max 64 chars
+[pi]: Program Identifier, 4 hex chars
+"""
+    examples = [
+        "live all"
+    ]
+    env_vars = {
+        "ALSA_INTERFACE": ("hw", "The ALSA interface"), 
+        "ALSA_CARD": ("BotWave", "The ALSA card name"), 
+        "ALSA_DEVICE": ("1", "The ALSA device"), 
+        "ALSA_RATE": ("48000", "The ALSA rate to expect"), 
+        "ALSA_CHANNELS": ("2", "The ALSA channels to expect"), 
+        "ALSA_PERIODSIZE": ("2", "The ALSA period size to expect"), 
+        "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
+        "DEFAULT_PS": ("BotWave", "The default program service"),
+        "DEFAULT_RT": ("Live", "The default radio text"),
+        "DEFAULT_PI": ("FFFF", "The default program identifier")
+    }
 
     async def handle(
         self,

--- a/server/ops/morse.py
+++ b/server/ops/morse.py
@@ -22,7 +22,36 @@ class MorseOp(CliOp):
 
     name = "morse"
     syntax = "<targets> <text|file> [wpm] [frequency] [loop] [ps] [rt] [pi]"
+    short_help = "Convert text to Morse code and broadcast it on client(s)"
+    long_help = """\
+Convert text to Morse code, upload the resulting WAV to
+<targets>, and broadcast it.
+If the first argument is a <file>, read its content and
+convert it. If not, use the <text> itself.
 
+Generated .wav files are available into '/tmp/bw_morse/'.
+
+Other positional arguments:
+[wpm]: Words per minute to generate
+[frequency]: The frequency to broadcast to
+[loop]: If the audio should be looped
+[ps]: Program Service, max. 8 chars
+[rt]: Radio Text, max 64 chars
+[pi]: Program Identifier, 4 hex chars
+"""
+    examples = [
+        "morse all \"CQ CQ DE BOTWAVE\" 18 90 false BOTWAVE MORSE",
+        "morse pi1 message.txt"
+    ]
+    env_vars = {
+        "MORSE_FREQUENCY": ("700", "The audio frequency to generate the morse tone with"),
+        "MORSE_SAMPLE_RATE": ("48000", "The sample rate to generate the .wav file with"),
+        "DEFAULT_MORSE_WPM": ("20", "The default morse words per minute"),
+        "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
+        "DEFAULT_PS": ("BotWave", "The default program service"),
+        "DEFAULT_RT": ("Morse", "The default radio text"),
+        "DEFAULT_PI": ("FFFF", "The default program identifier")
+    }
     async def handle(
         self,
         targets: list[str] = [],

--- a/server/ops/queue.py
+++ b/server/ops/queue.py
@@ -9,6 +9,16 @@ class QueueOp(CliOp):
 
     name = "queue"
     syntax = "[+|-|*|!|?]"
+    short_help = "Manage the broadcast queue"
+    long_help = """\
+Manage the broadcast queue.
+Use 'queue ?' for detailed help on the available operators.
+"""
+    examples = [
+        "queue ?",
+        "queue +myfile.wav,myfile2.wav"
+    ]
+    env_vars = {}
 
     async def handle(self, is_cmd: bool = False, cmd_parts: list[str] = []):
         self.owner.queue.parse(' '.join(cmd_parts))

--- a/server/ops/rm.py
+++ b/server/ops/rm.py
@@ -12,6 +12,16 @@ class RemoveOp(CliOp):
 
     name = "rm"
     syntax = "<targets> <filename|glob>"
+    short_help = "Remove a file from client(s)"
+    long_help = """\
+Remove the given <filename> from the upload directory of
+<targets>. If a <glob> is passed, remove all matching files.
+"""
+    examples = [
+        "rm all broadcast.wav",
+        "rm all *"
+    ]
+    env_vars = {}
 
     async def handle(
             self,

--- a/server/ops/sh_cmd.py
+++ b/server/ops/sh_cmd.py
@@ -14,6 +14,17 @@ class ShellOp(CliOp):
 
     name = "<"
     syntax = "<command>"
+    short_help = "Run a shell command on the main OS"
+    long_help = """\
+Run a shell <command> on the machine hosting the server and
+print its output.
+"""
+    examples = [
+        "< df -h"
+    ]
+    env_vars = {
+        "CMD_INTERPRETER": ("", "The command interpreter to use to execute the given command")
+    }
 
     async def handle(self, command: str = "", is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:
@@ -81,6 +92,17 @@ class PipeOp(CliOp):
     
     name = "|"
     syntax = "<command>"
+    short_help = "Run a shell command and pipe each output line as a BotWave command"
+    long_help = """\
+Run a shell <command> and dispatch each line of its output
+as a separate BotWave command.
+"""
+    examples = [
+        "| cat commands.txt"
+    ]
+    env_vars = {
+        "CMD_INTERPRETER": ("", "The command interpreter to use to execute the given command")
+    }
 
     async def handle(self, command: str = "", is_cmd: bool = False, cmd_parts: list[str] = []):
         if is_cmd:

--- a/server/ops/sstv.py
+++ b/server/ops/sstv.py
@@ -22,7 +22,38 @@ class SSTVOp(CliOp):
 
     name = "sstv"
     syntax = "<targets> <image_path> [mode] [frequency] [loop] [ps] [rt] [pi]"
+    short_help = "Convert an image into SSTV audio and broadcast it on client(s)"
+    long_help = """\
+Convert an <image_path> into SSTV audio, upload the
+resulting WAV to <targets>, and broadcast it.
+If [mode] is not specified, automatically selects the best
+mode available.
 
+Available modes: MartinM1, MartinM2, ScottieS1, ScottieS2,
+ScottieDX, Robot36, PasokonP3, PasokonP5, PasokonP7, PD90,
+PD120, PD160, PD180, PD240, PD290, WraaseSC2120, WraaseSC2180,
+Robot8BW, Robot24BW
+
+Generated .wav files are available into '/tmp/bw_sstv/'.
+
+Other positional arguments:
+[loop]: If the audio should be looped
+[ps]: Program Service, max. 8 chars
+[rt]: Radio Text, max 64 chars
+[pi]: Program Identifier, 4 hex chars
+"""
+    examples = [
+        "sstv all mycat.png"
+        "sstv all mycat.png Robot36 90 false 'My Cat!' 'PsPs Cutie' FFFF"
+    ]
+    env_vars = {
+        "SSTV_SAMPLE_RATE": ("48000", "The sample rate to generate the .wav file with"),
+        "SSTV_DEFAULT_MODE": ("auto", "The default SSTV mode"),
+        "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
+        "DEFAULT_PS": ("BotWave", "The default program service"),
+        "DEFAULT_RT": ("<image filename>", "The default radio text"),
+        "DEFAULT_PI": ("FFFF", "The default program identifier")
+    }
     async def handle(
         self,
         targets: list[str] = [],

--- a/server/ops/sstv.py
+++ b/server/ops/sstv.py
@@ -43,7 +43,7 @@ Other positional arguments:
 [pi]: Program Identifier, 4 hex chars
 """
     examples = [
-        "sstv all mycat.png"
+        "sstv all mycat.png",
         "sstv all mycat.png Robot36 90 false 'My Cat!' 'PsPs Cutie' FFFF"
     ]
     env_vars = {

--- a/server/ops/start.py
+++ b/server/ops/start.py
@@ -17,6 +17,28 @@ class StartOp(CliOp):
 
     name = "start"
     syntax = "<targets> <file> [frequency] [loop] [ps] [rt] [pi]"
+    short_help = "Start broadcasting on client(s)"
+    long_help = """\
+Start broadcasting <file> from the upload directory on
+<targets>, on the given [frequency].
+
+Other positional arguments:
+[loop]: If the audio should be looped
+[ps]: Program Service, max. 8 chars
+[rt]: Radio Text, max 64 chars
+[pi]: Program Identifier, 4 hex chars
+"""
+    examples = [
+        "start all myfile.wav"
+        "start all myfile.wav 96.9 true 'BotWave'"
+    ]
+    env_vars = {
+        "WAIT_START": ("true", "If the broadcast should be delayed by len(clients) * 5 for better syncing"),
+        "DEFAULT_FREQ": ("90", "The default frequency to broadcast to"),
+        "DEFAULT_PS": ("BotWave", "The default program service"),
+        "DEFAULT_RT": ("<filename>", "The default radio text"),
+        "DEFAULT_PI": ("FFFF", "The default program identifier")
+    }
 
     async def handle(
         self,

--- a/server/ops/status.py
+++ b/server/ops/status.py
@@ -13,6 +13,23 @@ class StatusOp(CliOp):
 
     name = "status"
     syntax = "[targets]"
+    short_help = "Show server status, and optionally the broadcast status of client(s)"
+    long_help = """\
+Show the server's status: connected client count, ports and
+eventual remote CLI information.
+If [targets] is provided, also shows the broadcast status of
+those clients.
+"""
+    examples = [
+        "status",
+        "status all"
+    ]
+    env_vars = {
+        "PORT": ("9939", "The server port"),
+        "FPORT": ("9921", "The file transfer port"),
+        "PASSKEY": ("", "The authentication passkey"),
+        "REMOTE_CLI_PORT": ("", "The remote CLI port")
+    }
 
     async def handle(
             self,

--- a/server/ops/stop.py
+++ b/server/ops/stop.py
@@ -12,6 +12,15 @@ class StopOp(CliOp):
 
     name = "stop"
     syntax = "<targets>"
+    short_help = "Stop broadcasting on client(s)"
+    long_help = """\
+Stop the current broadcast on the given <targets>, and
+stop the local ALSA recorder.
+"""
+    examples = [
+        "stop all"
+    ]
+    env_vars = {}
 
     async def handle(
         self,

--- a/server/ops/sync.py
+++ b/server/ops/sync.py
@@ -32,6 +32,28 @@ class SyncOp(CliOp):
 
     name = "sync"
     syntax = "<targets|folder> <source_target|source_folder>"
+    short_help = "Synchronize files across clients or to/from local folders"
+    long_help = """\
+Synchronize files between <targets|folder> and
+<source_target|source_folder>. Supports three directions:
+
+  - Local folder to client(s): replaces the target clients'
+    files with the ones in the source folder.
+  - Client to local folder: downloads all files from the
+    source client into the target folder.
+  - Client to client(s): downloads the source client's files
+    to a temporary folder, then uploads them to the targets.
+
+This feature is experimental and may be unstable.
+"""
+    examples = [
+        "sync all pi1",
+        "sync pi2,pi3 music",
+        "sync backup/ pi1"
+    ]
+    env_vars = {
+        "EXTRA_ALLOWED_DIRS": ("", "Colon-separated list of extra directories allowed as sync sources")
+    }
 
     async def handle(
             self,

--- a/server/ops/update.py
+++ b/server/ops/update.py
@@ -17,6 +17,16 @@ class UpdateOp(CliOp):
 
     name = "update"
     syntax = "<targets> [version]"
+    short_help = "Request client(s) to update and restart"
+    long_help = """\
+Request the given <targets> to update and restart.
+Omit [version] to update to the latest release.
+"""
+    examples = [
+        "update all",
+        "update all v1.0.0-oak"
+    ]
+    env_vars = {}
 
     async def handle(
             self,

--- a/server/ops/upload.py
+++ b/server/ops/upload.py
@@ -24,6 +24,19 @@ class UploadOp(CliOp):
 
     name = "upload"
     syntax = "<targets> <file|folder>"
+    short_help = "Upload a WAV file or a folder's files to client(s)"
+    long_help = """\
+Upload a <file> or every supported file in a <folder> to
+<targets>. Converts files to .wav if they're in a supported
+format.
+"""
+    examples = [
+        "upload all broadcast.wav",
+        "upload pi1,pi2 /home/bw/lib"
+    ]
+    env_vars = {
+        "MAX_UPLOAD_SIZE": ("524288000", "The maximum accepted file size in bytes (default 500 MB)")
+    }
 
     async def handle(
             self,

--- a/shared/ops.py
+++ b/shared/ops.py
@@ -13,6 +13,8 @@ class GeneralOp:
 class CliOp:
     name: str = ""
     syntax: str = ""
+    short_help: str = ""
+    long_help: str = ""
 
     def __init__(self, owner: Any, registry: "Registry"):
         self.owner = owner

--- a/shared/ops.py
+++ b/shared/ops.py
@@ -16,6 +16,7 @@ class CliOp:
     short_help: str = ""
     long_help: str = ""
     examples: list[str] = []
+    env_vars: dict[str, tuple[str, str]] = {}
 
     def __init__(self, owner: Any, registry: "Registry"):
         self.owner = owner

--- a/shared/ops.py
+++ b/shared/ops.py
@@ -15,6 +15,7 @@ class CliOp:
     syntax: str = ""
     short_help: str = ""
     long_help: str = ""
+    examples: list[str] = []
 
     def __init__(self, owner: Any, registry: "Registry"):
         self.owner = owner


### PR DESCRIPTION
This PR includes a rework of the existing `help` command, both in `bw-server` and `bw-local`.

Previously, the command showed a hardcoded string of all commands, with little to no description, and was a really big chunk of text. 

Now, typing `help` displays a list of all available commands alongside their required syntax and a short description. Running `help <command>` provides detailed help for a specific command, including an extended description, examples, and relevant environment variables.

Additionally, custom commands are now directly included into the commands list.

Example output (`bw-local`):
```
botwave › help
BotWave Local Client - Help

 Available Commands ────────────────────

dl <url>              Download an audio file from a URL
get <keys|glob>       Get one or more environment variables
set <key> <value>     Set an environment variable
exit                  Shutdown and exit the local client
handlers              List all handlers and custom commands available
help                  Show general or command-specific help
lf                    List files in the upload directory
live                  Start a live audio broadcast
morse <text|file>     Convert text to morse code and broadcast it
queue                 Manage the broadcast queue
rm <filename|glob>    Remove a file from the upload directory
< <command>           Run a shell command on the host machine
| <command>           Run a shell command and pipe each output line as a BotWave command
sstv <image_path>     Convert an image into SSTV audio and broadcast it
start <file>          Start broadcasting a WAV file
status                Show current broadcast and remote status
stop                  Stop the current broadcast
upload <file|dir>     Upload a file or folder to the upload directory

Use 'help [command]' to see specific help about a command

botwave › help sstv
› sstv <image_path> [mode] [frequency] [loop] [ps] [rt] [pi]

Convert an <image_path> into SSTV audio and broadcast it.
If [mode] is not specified, automatically selects the best
mode available.

Available modes: MartinM1, MartinM2, ScottieS1, ScottieS2,
ScottieDX, Robot36, PasokonP3, PasokonP5, PasokonP7, PD90,
PD120, PD160, PD180, PD240, PD290, WraaseSC2120, WraaseSC2180,
Robot8BW, Robot24BW

Generated .wav files are available into '/tmp/bw_sstv/'.

Other positional arguments:
[loop]: If the audio should be looped
[ps]: Program Service, max. 8 chars
[rt]: Radio Text, max 64 chars
[pi]: Program Identifier, 4 hex chars

Examples:
  - sstv image.png
  - sstv image.png Robot36 96.9 true 'BotWave'

Environment variables:
  - SSTV_SAMPLE_RATE (48000): The sample rate to generate the .wav file with
  - BACKEND_PATH (bw_custom): The path to the broadcast backend
  - BACKEND_BYPASS_CACHE (false): If the backend manager should discard its cached backend path
  - SKIP_CHECKS (false): If the backend manager should skip its own system requirements checks
  - SSTV_DEFAULT_MODE (auto): The default SSTV mode
  - DEFAULT_FREQ (90): The default frequency to broadcast to
  - DEFAULT_PS (BotWave): The default program service
  - DEFAULT_RT (<image filename>): The default radio text
  - DEFAULT_PI (FFFF): The default program identifier
```