### PR TITLE
[Feature]: A new, stricter custom command metadata format

### DIFF
--- a/shared/custom_cmds.py
+++ b/shared/custom_cmds.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shlex
 from pathlib import Path
 
@@ -8,7 +7,6 @@ from shared.logger import Log
 
 class CustomCommand:
     path: Path
-    version: int = 0
     name: str = ""
     syntax: str = ""
     short_help: str = ""
@@ -111,8 +109,8 @@ class CCMD:
                 line = line[2:].strip()
                 ccmd.long_help += line + "\n"
 
-        if not (ccmd.name and ccmd.version and ccmd.syntax and ccmd.short_help and ccmd.long_help):
-            raise ValueError("ccmd is declared as v2, but it doesn't provide all the required meta fields")
+        if not (ccmd.name and ccmd.syntax and ccmd.short_help and ccmd.long_help):
+            raise ValueError("ccmd is being parsed as ccmdv2, but it doesn't provide all the required meta fields")
 
     def parse_meta_v2(self, ccmd: CustomCommand, line: str):
         line = line[2:].strip()
@@ -124,13 +122,7 @@ class CCMD:
         command = parts[0]
         value = parts[1]
 
-        if command == "cmdver":
-            if not bool(re.fullmatch(r'v\d+', value)):
-                raise ValueError(f"cmdver requires a valid version as value (vN), got {value}")
-
-            ccmd.version = int(value[1:])
-
-        elif command == "syntax":
+        if command == "syntax":
             ccmd.syntax = value
 
         elif command == "short_help":

--- a/shared/custom_cmds.py
+++ b/shared/custom_cmds.py
@@ -109,7 +109,7 @@ class CCMD:
                 line = line[2:].strip()
                 ccmd.long_help += line + "\n"
 
-        if not (ccmd.name and ccmd.syntax and ccmd.short_help and ccmd.long_help):
+        if not (ccmd.name and ccmd.short_help and ccmd.long_help):
             raise ValueError("ccmd is being parsed as ccmdv2, but it doesn't provide all the required meta fields")
 
     def parse_meta_v2(self, ccmd: CustomCommand, line: str):

--- a/shared/custom_cmds.py
+++ b/shared/custom_cmds.py
@@ -1,7 +1,18 @@
 import os
+import re
+import shlex
 from pathlib import Path
 
 from shared.env import Env
+from shared.logger import Log
+
+class CustomCommand:
+    path: Path
+    version: int = 0
+    name: str = ""
+    syntax: str = ""
+    short_help: str = ""
+    long_help: str = ""
 
 class CCMD:
     def __init__(self, is_server: bool = True):
@@ -29,8 +40,8 @@ class CCMD:
 
         return first_line == shebang or first_line == wildcard
     
-    def get_all(self) -> list[dict[str, str | list[str]]]:
-        matches: list[dict[str, str | list[str]]] = []
+    def get_all(self) -> list[CustomCommand]:
+        matches: list[CustomCommand] = []
 
         handlers_path = Path(self.handlers_dir)
         for file in handlers_path.rglob("*.cmd"):
@@ -53,23 +64,77 @@ class CCMD:
                     if first_line != shebang and first_line != wildcard:
                         continue
 
-                    # process help lines 
-                    help_lines: list[str] = []
-                    for line in lines[1:]:
-                        line = line.rstrip("\n")
+                    ccmd = CustomCommand()
+                    ccmd.path = full_path
+                    ccmd.name = cmd_name
 
-                        if line.startswith("#"):
-                            # remove '#' and after char
-                            help_lines.append(line[1:])
-                        else:
-                            break
+                    # consider commands with #> and #? as v2
+                    if any((line.startswith("#>") or line.startswith("#?")) for line in lines):
+                        Log.debug(f"ccmd parsing: treating {file} as v2")
+                        self.parse_ccmd_v2(ccmd, lines)
 
-                    matches.append({
-                        "name": cmd_name,
-                        "help": help_lines
-                    })
+                    else:
+                        self.parse_ccmd_v0(ccmd, lines)
 
-            except:
+                    matches.append(ccmd)
+
+            except Exception as e:
+                Log.error(f"Error while parsing subcommand {file}: {e}")
                 continue
 
         return matches
+
+    def parse_ccmd_v0(self, ccmd: CustomCommand, lines: list[str]):
+        help_lines: list[str] = []
+        for line in lines[1:]:
+            line = line.rstrip("\n")
+
+            if line.startswith("#"):
+                # remove '#' and after char
+                help_lines.append(line[1:])
+            else:
+                break
+
+        
+        ccmd.syntax = help_lines[0].lower().replace(ccmd.name, "") if len(help_lines) > 0 else "Unknown syntax"
+        ccmd.short_help = f"The {ccmd.name} custom command"
+        ccmd.long_help = ' '.join(help_lines[1:])
+
+
+    def parse_ccmd_v2(self, ccmd: CustomCommand, lines: list[str]):
+        # parse meta
+        for line in lines:
+            if line.startswith("#>"):
+                self.parse_meta_v2(ccmd, line)
+
+            elif line.startswith("#?"):
+                line = line[2:].strip()
+                ccmd.long_help += line + "\n"
+
+        if not (ccmd.name and ccmd.version and ccmd.syntax and ccmd.short_help and ccmd.long_help):
+            raise ValueError("ccmd is declared as v2, but it doesn't provide all the required meta fields")
+
+    def parse_meta_v2(self, ccmd: CustomCommand, line: str):
+        line = line[2:].strip()
+        parts = shlex.split(line)
+
+        if len(parts) != 2:
+            raise ValueError(f"ccmdmeta parsing error: expected '#> command \"value\"', got: {line}")
+
+        command = parts[0]
+        value = parts[1]
+
+        if command == "cmdver":
+            if not bool(re.fullmatch(r'v\d+', value)):
+                raise ValueError(f"cmdver requires a valid version as value (vN), got {value}")
+
+            ccmd.version = int(value[1:])
+
+        elif command == "syntax":
+            ccmd.syntax = value
+
+        elif command == "short_help":
+            ccmd.short_help = value
+
+        else:
+            raise ValueError(f"unexpected command while parsing ccmdmeta: {command}")

--- a/shared/custom_cmds.py
+++ b/shared/custom_cmds.py
@@ -117,7 +117,7 @@ class CCMD:
         parts = shlex.split(line)
 
         if len(parts) != 2:
-            raise ValueError(f"ccmdmeta parsing error: expected '#> command \"value\"', got: {line}")
+            raise ValueError(f"ccmdmeta parsing error: expected '#> keyword \"value\"', got: {line}")
 
         command = parts[0]
         value = parts[1]
@@ -129,4 +129,4 @@ class CCMD:
             ccmd.short_help = value
 
         else:
-            raise ValueError(f"unexpected command while parsing ccmdmeta: {command}")
+            raise ValueError(f"unexpected keyword while parsing ccmdmeta: {command}")

--- a/shared/ops/help.py
+++ b/shared/ops/help.py
@@ -1,12 +1,12 @@
 import re
 from typing import Any, Callable
 
+from shared.custom_cmds import CustomCommand
 from shared.logger import Log
 from shared.ops import CliOp
 
 class CommandInfo:
     name: str
-    is_custom: bool
     required_syntax: str
     full_syntax: str
     short_help: str
@@ -63,7 +63,7 @@ Custom commands (.cmd files) are included in both views.
 
                     Log.print("›", "bright_green", end=" ")
                     Log.print(
-                        f"{cmd_info.name if not cmd_info.is_custom else ''} {cmd_info.full_syntax or cmd_info.name}".strip(),
+                        f"{cmd_info.name} {cmd_info.full_syntax}".strip(),
                         "yellow",
                         end="\n\n"
                         )
@@ -86,7 +86,6 @@ Custom commands (.cmd files) are included in both views.
     def get_cmd_info(self, cmd_op: CliOp) -> CommandInfo:
         cmd_info = CommandInfo()
         cmd_info.name = cmd_op.name
-        cmd_info.is_custom = False
         cmd_info.full_syntax = cmd_op.syntax
         cmd_info.short_help = cmd_op.short_help
         cmd_info.long_help = cmd_op.long_help
@@ -119,19 +118,19 @@ Custom commands (.cmd files) are included in both views.
 
         return cmd_info
 
-    def get_ccmd_info(self, custom_command: dict[Any, Any]) -> CommandInfo:
+    def get_ccmd_info(self, ccmd: CustomCommand) -> CommandInfo:
         cmd_info = CommandInfo()
-        cmd_info.name = custom_command["name"]
-        cmd_info.is_custom = True
-
-        help = custom_command["help"]
-        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', help[0])) if len(help) > 0 else ""
-        cmd_info.full_syntax = help[0].strip() if len(help) > 0 else ""
-        cmd_info.short_help = help[1].strip() if len(help) > 1 else f"The {cmd_info.name} custom command"
-        cmd_info.long_help = '\n'.join(help)
+        cmd_info.name = ccmd.name
+        cmd_info.short_help = ccmd.short_help
+        cmd_info.long_help = ccmd.long_help
+        cmd_info.full_syntax = ccmd.syntax
+        cmd_info.required_syntax = ' '.join(re.findall(r'<[^>]*>', ccmd.syntax))
 
         def full_help():
             Log.print(cmd_info.long_help)
+
+            if "target" in cmd_info.full_syntax:
+                self.print_targets()
 
         cmd_info.full_help = full_help
 


### PR DESCRIPTION
This PR adds a new v2 custom command metadata format. It enforces a clearer structure for custom command help documentation. The old format remains supported.

The new format implies two main changes:
- Metadata lines should start with `#> ` and contain a `keyword` followed by a `"value"`.
- Help lines should start with `#? ` and be followed by arbitrary content.

**The first-line shebang remains unchanged and required.**

Supported metadata commands:
- `short_help` (required): a summary of what the command does
- `syntax` (optional): the command's argument syntax, without the command name. Required arguments have to be wrapped with `<>`. It is recommanded to wrap optional commands with `[]` but not enforced.

### Old format example
```sh
#!/*/wtt
# wtt [TCP PORT]
#   Starts a bridge between the remote command port and a TCP socket
#   Default TCP port: 9940
#   Examples:
#     wtt
#     wtt 9950

< /opt/BotWave/scripts/wtt/start.sh {BW_ARGV1}
```

### New format example
```sh
#!/*/wtt
#> syntax "[WTT_PORT]"
#> short_help "Starts a WebSocket-to-TCP bridge"
#? Starts a bridge between the remote command port and a TCP socket on [WTT_PORT]
#? Default TCP port: 9940
#?
#? Examples:
#?   - wtt
#?   - wtt 9950
#?
#? Environment variables:
#?   - REMOTE_CMD_PORT (): The remote cmd port to bridge commands to. If unset, the application won't start
#?   - WTT_PORT (9940): The port to listen for TCP connections to

< /opt/BotWave/scripts/wtt/start.sh {BW_ARGV1}
```